### PR TITLE
Add CI, license, MSRV, and no-telemetry badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # agent-walker
 
+[![CI](https://github.com/miiiiiiich/agent-walker/actions/workflows/ci.yml/badge.svg)](https://github.com/miiiiiiich/agent-walker/actions/workflows/ci.yml)
+[![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
+[![MSRV](https://img.shields.io/badge/rustc-1.93+-blue.svg)](https://www.rust-lang.org)
+[![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen.svg)](#privacy)
+
 **A terminal dashboard for your local AI coding-agent usage** — tokens, real
 API-equivalent cost, projects, tools, and autonomy metrics, aggregated from
 the logs that Claude Code, Codex CLI, and Antigravity CLI already write to


### PR DESCRIPTION
Adds four status badges under the title: CI, license (MIT OR Apache-2.0), MSRV (1.93+), and a custom "no telemetry" badge linking to the Privacy section.

All four resolve on the public repo; anchors (`#privacy`, `#license`) verified present.