### PR TITLE
Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-06-21
+
+### Added
+
+- Windows support. Prebuilt binaries are now published for
+  `x86_64-pc-windows-msvc`, and the dashboard discovers logs under
+  `%USERPROFILE%` (`.claude\projects`, `.codex\sessions`,
+  `.gemini\antigravity-cli`).
+- CI now exercises `cargo test` on `windows-latest` alongside macOS and Linux.
+
+### Changed
+
+- Path resolution went through `dirs::home_dir`, so no part of the codebase
+  reads `HOME` directly anymore. WSL installs keep working with their existing
+  Linux-style paths.
+
 ## [0.2.1] - 2026-06-21
 
 ### Changed
@@ -39,12 +55,12 @@ First public release with the codename system and the shareable stats card.
 
 - Antigravity token and cost figures are not counted — its usage lives in an
   undocumented protobuf store.
-- Windows is not yet supported; log discovery relies on `$HOME`.
 
 ## [0.1.0] - 2026-06-20
 
 Initial npm packaging.
 
+[0.3.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.3.0
 [0.2.1]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.2.1
 [0.2.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.2.0
 [0.1.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ First public release with the codename system and the shareable stats card.
 ### Added
 
 - Terminal dashboard aggregating local AI coding-agent logs (Claude Code and
-  Codex CLI), parsed in parallel and cached per file for ~100 ms warm starts.
+  Codex CLI), parsed in parallel and cached per file so warm starts only
+  reparse files whose `(mtime, size)` changed.
 - API-equivalent cost windows (today / 7d / 30d / period), cache-aware and
   priced from the LiteLLM pricing database.
 - Per-repository token breakdown, stacked per-model daily bars, a GitHub-style
@@ -43,7 +44,8 @@ First public release with the codename system and the shareable stats card.
 - Autonomy view: a turn-duration histogram weighted toward the 20-minute-plus
   unattended range.
 - Shareable "codename" stats card — a usage-based rank you can copy to the
-  clipboard or save to `~/Downloads`. Repository names never appear on it.
+  clipboard or save to your OS Downloads folder. Repository names never
+  appear on it.
 - Opt-in Antigravity CLI collection via `--agy` (activity only; its logs carry
   no token usage).
 - Shell completions (`--completions`) and card export (`--share <path>`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "crossterm",
+ "dirs",
  "ratatui",
  "rayon",
  "resvg",
@@ -552,6 +553,27 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1162,6 +1184,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "line-clipping"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1450,6 +1481,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1847,6 +1884,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2982,11 +3030,20 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3000,19 +3057,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3022,9 +3100,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3040,9 +3130,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3052,9 +3154,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-walker"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-walker"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Local AI coding-agent usage dashboard — tokens, cost, projects, autonomy."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ bincode = "1.3.3"
 clap = { version = "4.5.53", features = ["derive"] }
 clap_complete = "4.5.60"
 crossterm = "0.29.0"
+dirs = "5.0.1"
 ratatui = "0.30.1"
 rayon = "1.11.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/README.ja.md
+++ b/README.ja.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/miiiiiiich/agent-walker/actions/workflows/ci.yml/badge.svg)](https://github.com/miiiiiiich/agent-walker/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#ライセンス)
 [![MSRV](https://img.shields.io/badge/rustc-1.93+-blue.svg)](https://www.rust-lang.org)
-[![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen.svg)](#プライバシー)
 
 **English: [README.md](README.md)**
 
@@ -26,8 +25,8 @@ AI エージェントがマシンに残すログから作る、ローカルの�
 
 ## プライバシー
 
-- ログは**マシンの外に出ない**。テレメトリも分析もなし。
-- 唯一の通信は、公開モデル価格メタデータの取得（[LiteLLM 価格DB](https://github.com/BerriAI/litellm)・MIT ライセンス）。ログ内容も利用状況も一切送らない。
+- ログは**マシンの外に出ない** — 利用状況やエラーをサーバーに送ることはしない。
+- 唯一の outbound 通信は、ダッシュボードがレポートを読み込み・再読み込みするときに発行する、公開モデル価格メタデータ（[LiteLLM 価格DB](https://github.com/BerriAI/litellm)・MIT ライセンス）への `GET`。ログ内容も利用状況も送らないが、`git pull` と同じく GitHub の CDN 側からは IP が見える。気になるならファイアウォールで遮断する／オフラインで使う。
 - リリースバイナリは [GitHub Artifact Attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations) 付き：
 
 ```sh
@@ -36,7 +35,7 @@ gh attestation verify agent-walker-aarch64-apple-darwin.tar.xz -R miiiiiiich/age
 
 ## 使う
 
-インストール不要 — `npx` / `bunx` が環境に合ったバイナリを取ってきて実行：
+インストール不要 — `npx` / `bunx` がプラットフォーム（macOS arm64/x64・Linux arm64/x64 GNU・Windows x64）に合ったバイナリを取ってきて実行：
 
 ```sh
 npx agent-walker
@@ -50,14 +49,14 @@ bunx agent-walker
 | `↑` `↓` / `j` `k` / `PgUp` `PgDn` | スクロール |
 | `1`–`4` | タブへジャンプ |
 | `r` | リロード |
-| `s` | カードを共有（画像コピー / `~/Downloads` に保存） |
+| `s` | カードを共有（画像コピー / OS の Downloads フォルダに保存） |
 | `q` / `Esc` / `Ctrl-C` | 終了 |
 
 フラグ：
 
 | フラグ | 何をする |
 |---|---|
-| `--days <N>` | グラフの集計期間（既定 30。codename は常に直近 30 日） |
+| `--days <N>` | グラフの集計期間（既定 30。codename のトークン量レベルは常に直近 30 日からとるので、`--days` を変えても rank はぶれない） |
 | `--share <path>` | カードを PNG 出力＋キャプション表示して終了 |
 | `--agy` | Antigravity も読む（既定オフ） |
 | `--no-cache` | パースキャッシュを無視して全再走査 |
@@ -82,7 +81,7 @@ bunx agent-walker
 
 各エージェントはトークンとキャッシュの数え方が違う。上の per-agent ページに、何を読むか・トークン/キャッシュ/コストの数え方・注意点を書いてある（英語）。
 
-並列パース＋ファイル単位キャッシュ（`~/.cache/agent-walker/`）で warm start は ~100ms。ログは信頼しない入力として扱い、壊れた行は数えてスキップ（評価はしない）。
+並列パース＋ファイル単位キャッシュ（`~/.cache/agent-walker/`）で、warm start は `(mtime, size)` が変わったログファイルだけ再パースする。ログは信頼しない入力として扱い、壊れた行は数えてスキップ（評価はしない）。
 
 ### 30日より前も残すには
 
@@ -96,8 +95,8 @@ Claude Code は既定で**約30日でトランスクリプトを整理する**�
 
 ### 注意・制約
 
-- コストは **API 換算の見積もり**（実請求ではない）。LiteLLM の価格、キャッシュ読み書きは別レート。日付は COST パネルに表示。
-- トークンは**キャッシュ込み**（入力 + 出力 + キャッシュ書込 + 読込）。Claude は毎ターン全コンテキストを再送するので、合計の約95%はキャッシュ読込＝安価な再読込で、新規の作業量とは別物。
+- コストは **API 換算の見積もり**（実請求ではない）。LiteLLM の価格、キャッシュ読み書きは別レート。pricing fetch 日付は、pricing が読めて端末幅に余裕があるとき COST パネルに表示される。
+- トークンは**キャッシュ込み**（入力 + 出力 + キャッシュ書込 + 読込）。Claude は毎ターン全コンテキストを再送するので、ヘビーに使うほど合計の大部分はキャッシュ読込＝安価な再読込で、新規の作業量とは別物。
 - **Antigravity はトークン/コスト非計上**（中身不明な protobuf）。`--agy` 時も Combined の合計トークンには加算されない（活動のみ反映）。
 - 各エージェント自身の利用表示とは一致しない（集計の窓やキャッシュの数え方が違う）。
 - Antigravity のログのタイムスタンプはタイムゾーンなし＝ローカル想定。

--- a/README.ja.md
+++ b/README.ja.md
@@ -101,7 +101,7 @@ Claude Code は既定で**約30日でトランスクリプトを整理する**�
 - **Antigravity はトークン/コスト非計上**（中身不明な protobuf）。`--agy` 時も Combined の合計トークンには加算されない（活動のみ反映）。
 - 各エージェント自身の利用表示とは一致しない（集計の窓やキャッシュの数え方が違う）。
 - Antigravity のログのタイムスタンプはタイムゾーンなし＝ローカル想定。
-- Windows 未対応（ログ探索が `$HOME` 依存）。
+- Windows バイナリは 0.3 以降で配布。Windows Terminal / PowerShell で動き、ログは `%USERPROFILE%` から読む。WSL でもそのまま動く（パスは Linux 形式のまま）。
 
 ## ライセンス
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CI](https://github.com/miiiiiiich/agent-walker/actions/workflows/ci.yml/badge.svg)](https://github.com/miiiiiiich/agent-walker/actions/workflows/ci.yml)
 [![License: MIT OR Apache-2.0](https://img.shields.io/badge/license-MIT%20OR%20Apache--2.0-blue.svg)](#license)
 [![MSRV](https://img.shields.io/badge/rustc-1.93+-blue.svg)](https://www.rust-lang.org)
-[![No telemetry](https://img.shields.io/badge/telemetry-none-brightgreen.svg)](#privacy)
 
 **日本語: [README.ja.md](README.ja.md)**
 
@@ -33,10 +32,14 @@ reads the session logs on your disk and answers, in one screen:
 
 ## Privacy
 
-- Your logs **never leave your machine**. No telemetry, no analytics.
-- The only network access is a per-run fetch of public model-pricing metadata
-  from [LiteLLM's pricing database](https://github.com/BerriAI/litellm)
-  (MIT-licensed); no log content or usage data is ever sent.
+- Your logs **never leave your machine** — agent-walker does not phone home
+  with usage or error data.
+- The only outbound traffic is a `GET` of public model-pricing metadata from
+  [LiteLLM's pricing database](https://github.com/BerriAI/litellm)
+  (MIT-licensed) when the dashboard loads or reloads a report. It carries no
+  log content and no usage data, but it does let GitHub's CDN see your IP,
+  the same as any `git pull`. Block it with a firewall rule or run offline if
+  that matters to you.
 - Release binaries carry [GitHub Artifact Attestations](https://docs.github.com/en/actions/concepts/security/artifact-attestations):
 
 ```sh
@@ -45,8 +48,8 @@ gh attestation verify agent-walker-aarch64-apple-darwin.tar.xz -R miiiiiiich/age
 
 ## Use
 
-No install — `npx` / `bunx` fetch the right prebuilt binary for your platform
-and run it:
+No install — `npx` / `bunx` fetch the prebuilt binary for your platform
+(macOS arm64/x64, Linux arm64/x64 GNU, Windows x64) and run it:
 
 ```sh
 npx agent-walker
@@ -60,14 +63,14 @@ bunx agent-walker
 | `↑` `↓` / `j` `k` / `PgUp` `PgDn` | scroll |
 | `1`–`4` | jump to tab |
 | `r` | reload |
-| `s` | share your stats card (copy image / save to `~/Downloads`) |
+| `s` | share your stats card (copy image / save to your OS Downloads folder) |
 | `q` / `Esc` / `Ctrl-C` | quit |
 
 Flags:
 
 | Flag | What it does |
 |---|---|
-| `--days <N>` | Analysis window for the graphs (default 30; the codename always uses the last 30 days) |
+| `--days <N>` | Analysis window for the graphs (default 30; the codename's throughput level is always taken from the last 30 days, so the rank doesn't drift with `--days`) |
 | `--share <path>` | Render the stats card to a PNG, print its caption, and exit |
 | `--agy` | Also scan Antigravity logs (off by default — see [What it reads](#what-it-reads)) |
 | `--no-cache` | Rescan every log file, ignoring the parse cache |
@@ -99,9 +102,9 @@ Each agent counts and caches tokens differently. The per-agent pages above
 explain what's read, how tokens/cache/cost are counted, and the caveats.
 
 Everything is parsed in parallel and cached per file
-(`~/.cache/agent-walker/`), so warm starts take ~100 ms. Log lines are treated
-as untrusted input — malformed records are counted and skipped, never
-evaluated.
+(`~/.cache/agent-walker/`), so warm starts skip the bulk of the work and only
+reparse log files whose `(mtime, size)` changed. Log lines are treated as
+untrusted input — malformed records are counted and skipped, never evaluated.
 
 ### Keep more than 30 days of history
 
@@ -121,12 +124,12 @@ indefinitely; no setting needed.
 
 - Cost figures are **API-equivalent estimates** (what the same usage would
   cost on metered pricing), not your actual bill. Rates come from LiteLLM
-  with cache reads/writes priced separately; the rates date is shown in the
-  COST panel.
+  with cache reads/writes priced separately; the pricing-fetch date shows up
+  in the COST panel when pricing loads and the terminal has room for it.
 - Token totals are **cache-inclusive** (input + output + cache writes + cache
-  reads). Because Claude Code re-sends the full context every turn, ~95% of a
-  Claude total is cache reads — real but cheaply-billed context re-reads, not
-  new work. See [docs/claude.md](docs/claude.md).
+  reads). Claude Code re-sends the full context every turn, so for heavy
+  users the bulk of the total tends to be cache reads — real but cheaply
+  billed context re-reads, not new work. See [docs/claude.md](docs/claude.md).
 - **Antigravity tokens/cost are not counted** — its usage lives in an
   undocumented protobuf format. With `--agy` on, the Combined token total still
   excludes it (activity only); see [docs/agy.md](docs/agy.md).

--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ indefinitely; no setting needed.
   different time windows and count cache reads differently. See the per-agent
   pages above.
 - Antigravity log timestamps carry no timezone and are assumed to be local.
-- Windows is not supported yet (log discovery relies on `$HOME`).
+- Windows binaries are published from 0.3 onward; the dashboard runs in
+  Windows Terminal / PowerShell and reads logs from `%USERPROFILE%`. WSL
+  installs work too — paths just stay in their Linux form.
 
 ## License
 

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,8 +12,7 @@ installers = ["npm"]
 # A namespace to use when publishing this package to the npm registry
 npm-package = "agent-walker"
 # Target platforms to build apps for (Rust target-triple syntax)
-# (Windows is out for now: log discovery relies on $HOME.)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
 # Where to host releases
 hosting = "github"
 # Whether to attest build provenance with GitHub Artifact Attestations

--- a/src/app.rs
+++ b/src/app.rs
@@ -263,20 +263,17 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
 }
 
 fn default_claude_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".claude").join("projects"))
+    Ok(crate::paths::home_dir()?.join(".claude").join("projects"))
 }
 
 fn default_codex_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".codex").join("sessions"))
+    Ok(crate::paths::home_dir()?.join(".codex").join("sessions"))
 }
 
 fn default_agy_dir() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".gemini").join("antigravity-cli"))
-}
-
-fn home_dir() -> Result<PathBuf> {
-    let home = env::var_os("HOME").ok_or_else(|| anyhow!("HOME is not set"))?;
-    Ok(PathBuf::from(home))
+    Ok(crate::paths::home_dir()?
+        .join(".gemini")
+        .join("antigravity-cli"))
 }
 
 fn demo_enabled() -> bool {

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -64,8 +64,17 @@ fn project_label(path: &Path, root: &Path) -> Option<String> {
 }
 
 fn normalize_project_name(directory: &str) -> String {
-    let home_prefix = std::env::var("HOME")
-        .map(|home| format!("{}-", home.replace('/', "-")))
+    // Claude Code names its project directories by flattening the cwd with
+    // every path separator replaced by `-`. Strip the home prefix so the label
+    // is a relative project path. Exact on macOS / Linux. Windows-native
+    // Claude Code's flattening rule (especially what happens to the `:` after
+    // the drive letter) hasn't been confirmed, so when the flattened prefix
+    // doesn't match we just fall back to the leading-`-` trim — the cwd field
+    // in the session is preferred as the project label whenever present.
+    let home_prefix = crate::paths::home_dir()
+        .ok()
+        .and_then(|home| home.to_str().map(ToOwned::to_owned))
+        .map(|home| format!("{}-", home.replace(['/', '\\'], "-")))
         .unwrap_or_default();
     let trimmed = directory
         .strip_prefix(&home_prefix)

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -67,14 +67,20 @@ fn normalize_project_name(directory: &str) -> String {
     // Claude Code names its project directories by flattening the cwd with
     // every path separator replaced by `-`. Strip the home prefix so the label
     // is a relative project path. Exact on macOS / Linux. Windows-native
-    // Claude Code's flattening rule (especially what happens to the `:` after
-    // the drive letter) hasn't been confirmed, so when the flattened prefix
-    // doesn't match we just fall back to the leading-`-` trim — the cwd field
+    // Claude Code's flattening rule isn't confirmed (especially whether the
+    // drive-letter `:` is dropped or rewritten), so we sanitize the home like
+    // the directory name itself — replacing `:` as well as the separators —
+    // and trim any trailing separator first so a home such as `/home/me/` or
+    // `D:\` doesn't yield a double-hyphen prefix. When the flattened prefix
+    // still doesn't match we fall back to the leading-`-` trim; the cwd field
     // in the session is preferred as the project label whenever present.
     let home_prefix = crate::paths::home_dir()
         .ok()
         .and_then(|home| home.to_str().map(ToOwned::to_owned))
-        .map(|home| format!("{}-", home.replace(['/', '\\'], "-")))
+        .map(|home| {
+            let trimmed = home.trim_end_matches(['/', '\\']);
+            format!("{}-", trimmed.replace([':', '/', '\\'], "-"))
+        })
         .unwrap_or_default();
     let trimmed = directory
         .strip_prefix(&home_prefix)

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -37,15 +37,21 @@ pub fn project_from_cwd(cwd: &str) -> String {
 /// filesystems are case-insensitive, so a cwd recorded as `c:\Users\me\…`
 /// must still match a home of `C:\Users\me`; compare case-insensitively but
 /// slice the original cwd so the rest of the path keeps its real casing.
-/// Requires a path-component boundary after the prefix so that
-/// `C:\Users\metadata` does not get stripped against home `C:\Users\me`.
+/// Backslashes and forward slashes are equivalent on Windows, so the prefix
+/// match normalizes both to `/` before comparing — npm/Node tooling often
+/// records cwds with forward slashes even on Windows. Requires a path-
+/// component boundary after the prefix so that `C:\Users\metadata` does not
+/// get stripped against home `C:\Users\me`.
 #[cfg(windows)]
 fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
     // `get` keeps us safe if `home.len()` lands inside a multi-byte UTF-8
     // character in `cwd`; `split_at` would panic there.
     let head = cwd.get(..home.len())?;
     let rest = cwd.get(home.len()..)?;
-    if !head.eq_ignore_ascii_case(home) {
+    if !head
+        .replace('\\', "/")
+        .eq_ignore_ascii_case(&home.replace('\\', "/"))
+    {
         return None;
     }
     if !rest.is_empty() && !rest.starts_with(['/', '\\']) {
@@ -54,10 +60,16 @@ fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
     Some(rest.trim_start_matches(['/', '\\']).to_owned())
 }
 
+/// Same shape on Unix: require a path-component boundary so that home
+/// `/Users/me` does not silently strip a cwd like `/Users/metadata/app` into
+/// `tadata/app` (an attribution bug the previous `{home}/` prefix avoided).
 #[cfg(not(windows))]
 fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
-    cwd.strip_prefix(home)
-        .map(|rest| rest.trim_start_matches(['/', '\\']).to_owned())
+    let rest = cwd.strip_prefix(home)?;
+    if !rest.is_empty() && !rest.starts_with('/') {
+        return None;
+    }
+    Some(rest.trim_start_matches('/').to_owned())
 }
 
 /// Events extracted from a single log file. The unit of caching: parsed once,
@@ -278,6 +290,13 @@ fn store_cache(cache_name: &str, cache: &CacheFile) {
     };
     let temp = path.with_extension("tmp");
     if fs::write(&temp, bytes).is_ok() {
+        // `fs::rename` on Windows refuses to overwrite an existing
+        // destination, so the cache file would never advance and every active
+        // user would reparse every log on every run. Remove the stale cache
+        // first (failure is harmless — the rename below reports the real
+        // outcome). Unix POSIX rename already overwrites atomically; the
+        // extra unlink there is a no-op on a missing path.
+        let _ = fs::remove_file(&path);
         let _ = fs::rename(&temp, &path);
     }
 }
@@ -409,7 +428,7 @@ mod tests {
 
     #[test]
     fn strip_home_prefix_unix() {
-        // Posix-only test: case-sensitive byte comparison.
+        // Posix-only test: case-sensitive byte comparison with boundary check.
         if !cfg!(windows) {
             assert_eq!(
                 strip_home_prefix("/Users/me/code/app", "/Users/me"),
@@ -417,12 +436,17 @@ mod tests {
             );
             // No prefix match → None so the caller falls back.
             assert_eq!(strip_home_prefix("/var/log/x", "/Users/me"), None);
+            // Non-boundary sibling does not strip (would otherwise yield
+            // "tadata/app" for "/Users/metadata/app").
+            assert_eq!(strip_home_prefix("/Users/metadata/app", "/Users/me"), None);
+            assert_eq!(strip_home_prefix("/Users/me-work/app", "/Users/me"), None);
         }
     }
 
     #[test]
     fn strip_home_prefix_windows_case_insensitive() {
-        // Windows-only test: case-insensitive prefix match with backslash trim.
+        // Windows-only test: case-insensitive prefix match with separator
+        // normalization and boundary check.
         if cfg!(windows) {
             assert_eq!(
                 strip_home_prefix(r"C:\Users\me\code\app", r"C:\Users\me"),
@@ -432,6 +456,12 @@ mod tests {
             assert_eq!(
                 strip_home_prefix(r"c:\users\me\code\app", r"C:\Users\me"),
                 Some(r"code\app".to_owned()),
+            );
+            // Mixed separators (forward-slashed cwd from npm/Node tooling,
+            // backslashed home from dirs::home_dir).
+            assert_eq!(
+                strip_home_prefix("C:/Users/me/code/app", r"C:\Users\me"),
+                Some("code/app".to_owned()),
             );
             // Non-boundary sibling does not strip.
             assert_eq!(

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -23,13 +23,41 @@ use crate::model::{Collection, DurationEvent, ScanStats, SessionTouch, ToolEvent
 const CACHE_VERSION: u32 = 7;
 
 /// Normalize a working-directory path into a project label: strip the home
-/// prefix, keep the real path separators ("/Users/me/code/app" -> "code/app").
+/// prefix, keep the real path separators ("/Users/me/code/app" -> "code/app",
+/// "C:\\Users\\me\\code\\app" -> "code\\app").
 pub fn project_from_cwd(cwd: &str) -> String {
-    let stripped = std::env::var("HOME")
+    let home = crate::paths::home_dir()
         .ok()
-        .and_then(|home| cwd.strip_prefix(&format!("{home}/")).map(ToOwned::to_owned))
-        .unwrap_or_else(|| cwd.to_owned());
-    stripped.trim_start_matches('/').to_owned()
+        .and_then(|home| home.to_str().map(ToOwned::to_owned));
+    home.and_then(|home| strip_home_prefix(cwd, &home))
+        .unwrap_or_else(|| cwd.trim_start_matches(['/', '\\']).to_owned())
+}
+
+/// Strip the home prefix and the single separator that follows it. Windows
+/// filesystems are case-insensitive, so a cwd recorded as `c:\Users\me\…`
+/// must still match a home of `C:\Users\me`; compare case-insensitively but
+/// slice the original cwd so the rest of the path keeps its real casing.
+/// Requires a path-component boundary after the prefix so that
+/// `C:\Users\metadata` does not get stripped against home `C:\Users\me`.
+#[cfg(windows)]
+fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
+    // `get` keeps us safe if `home.len()` lands inside a multi-byte UTF-8
+    // character in `cwd`; `split_at` would panic there.
+    let head = cwd.get(..home.len())?;
+    let rest = cwd.get(home.len()..)?;
+    if !head.eq_ignore_ascii_case(home) {
+        return None;
+    }
+    if !rest.is_empty() && !rest.starts_with(['/', '\\']) {
+        return None;
+    }
+    Some(rest.trim_start_matches(['/', '\\']).to_owned())
+}
+
+#[cfg(not(windows))]
+fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
+    cwd.strip_prefix(home)
+        .map(|rest| rest.trim_start_matches(['/', '\\']).to_owned())
 }
 
 /// Events extracted from a single log file. The unit of caching: parsed once,
@@ -205,11 +233,9 @@ struct CacheEntry {
 }
 
 fn cache_path(cache_name: &str) -> Option<PathBuf> {
-    let home = std::env::var_os("HOME")?;
     Some(
-        PathBuf::from(home)
-            .join(".cache")
-            .join("agent-walker")
+        crate::paths::cache_dir()
+            .ok()?
             .join(format!("{cache_name}-v{CACHE_VERSION}.bin")),
     )
 }
@@ -378,6 +404,40 @@ mod tests {
             version,
             offset_seconds,
             entries: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn strip_home_prefix_unix() {
+        // Posix-only test: case-sensitive byte comparison.
+        if !cfg!(windows) {
+            assert_eq!(
+                strip_home_prefix("/Users/me/code/app", "/Users/me"),
+                Some("code/app".to_owned()),
+            );
+            // No prefix match → None so the caller falls back.
+            assert_eq!(strip_home_prefix("/var/log/x", "/Users/me"), None);
+        }
+    }
+
+    #[test]
+    fn strip_home_prefix_windows_case_insensitive() {
+        // Windows-only test: case-insensitive prefix match with backslash trim.
+        if cfg!(windows) {
+            assert_eq!(
+                strip_home_prefix(r"C:\Users\me\code\app", r"C:\Users\me"),
+                Some(r"code\app".to_owned()),
+            );
+            // Lowercase drive letter still strips.
+            assert_eq!(
+                strip_home_prefix(r"c:\users\me\code\app", r"C:\Users\me"),
+                Some(r"code\app".to_owned()),
+            );
+            // Non-boundary sibling does not strip.
+            assert_eq!(
+                strip_home_prefix(r"C:\Users\metadata", r"C:\Users\me"),
+                None
+            );
         }
     }
 

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -24,13 +24,21 @@ const CACHE_VERSION: u32 = 7;
 
 /// Normalize a working-directory path into a project label: strip the home
 /// prefix, keep the real path separators ("/Users/me/code/app" -> "code/app",
-/// "C:\\Users\\me\\code\\app" -> "code\\app").
+/// "C:\\Users\\me\\code\\app" -> "code\\app"). A session whose cwd is exactly
+/// the home directory renders as "~" rather than an empty label so the
+/// PROJECTS row has something readable.
 pub fn project_from_cwd(cwd: &str) -> String {
     let home = crate::paths::home_dir()
         .ok()
         .and_then(|home| home.to_str().map(ToOwned::to_owned));
-    home.and_then(|home| strip_home_prefix(cwd, &home))
-        .unwrap_or_else(|| cwd.trim_start_matches(['/', '\\']).to_owned())
+    let stripped = home
+        .and_then(|home| strip_home_prefix(cwd, &home))
+        .unwrap_or_else(|| cwd.trim_start_matches(['/', '\\']).to_owned());
+    if stripped.is_empty() {
+        "~".to_owned()
+    } else {
+        stripped
+    }
 }
 
 /// Strip the home prefix and the single separator that follows it. Windows
@@ -44,6 +52,13 @@ pub fn project_from_cwd(cwd: &str) -> String {
 /// get stripped against home `C:\Users\me`.
 #[cfg(windows)]
 fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
+    // Trim any trailing separator on `home` (e.g. a drive-root home like
+    // `D:\`) so `home.len()` doesn't include the separator and the boundary
+    // check below stays meaningful.
+    let home = home.trim_end_matches(['/', '\\']);
+    if home.is_empty() {
+        return None;
+    }
     // `get` keeps us safe if `home.len()` lands inside a multi-byte UTF-8
     // character in `cwd`; `split_at` would panic there.
     let head = cwd.get(..home.len())?;
@@ -65,6 +80,12 @@ fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
 /// `tadata/app` (an attribution bug the previous `{home}/` prefix avoided).
 #[cfg(not(windows))]
 fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
+    // Trim any trailing slash on `home` so the boundary check below isn't
+    // defeated when `dirs::home_dir` returns `/home/me/`.
+    let home = home.trim_end_matches('/');
+    if home.is_empty() {
+        return None;
+    }
     let rest = cwd.strip_prefix(home)?;
     if !rest.is_empty() && !rest.starts_with('/') {
         return None;
@@ -290,13 +311,12 @@ fn store_cache(cache_name: &str, cache: &CacheFile) {
     };
     let temp = path.with_extension("tmp");
     if fs::write(&temp, bytes).is_ok() {
-        // `fs::rename` on Windows refuses to overwrite an existing
-        // destination, so the cache file would never advance and every active
-        // user would reparse every log on every run. Remove the stale cache
-        // first (failure is harmless — the rename below reports the real
-        // outcome). Unix POSIX rename already overwrites atomically; the
-        // extra unlink there is a no-op on a missing path.
-        let _ = fs::remove_file(&path);
+        // `std::fs::rename` is atomic on Unix and uses
+        // `MoveFileExW + MOVEFILE_REPLACE_EXISTING` on Windows, so the
+        // destination is overwritten on both platforms without an explicit
+        // unlink. Removing the file first would break the Unix atomicity
+        // guarantee and momentarily leave the cache missing for concurrent
+        // readers.
         let _ = fs::rename(&temp, &path);
     }
 }
@@ -440,6 +460,28 @@ mod tests {
             // "tadata/app" for "/Users/metadata/app").
             assert_eq!(strip_home_prefix("/Users/metadata/app", "/Users/me"), None);
             assert_eq!(strip_home_prefix("/Users/me-work/app", "/Users/me"), None);
+            // Trailing slash on home still strips cleanly.
+            assert_eq!(
+                strip_home_prefix("/Users/me/code", "/Users/me/"),
+                Some("code".to_owned()),
+            );
+            // Cwd equal to home returns empty (the caller substitutes "~").
+            assert_eq!(
+                strip_home_prefix("/Users/me", "/Users/me"),
+                Some(String::new())
+            );
+        }
+    }
+
+    #[test]
+    fn project_from_cwd_renames_home_to_tilde() {
+        // When the cwd resolves to the home directory itself, the project
+        // label is "~" rather than the empty string.
+        if !cfg!(windows) {
+            // Cannot easily inject a fake home; only verify the empty-string
+            // fallback path through a leading-slash cwd that the home strip
+            // would not match (so the trim-only branch runs) is never empty.
+            assert_eq!(project_from_cwd("/"), "~");
         }
     }
 
@@ -467,6 +509,11 @@ mod tests {
             assert_eq!(
                 strip_home_prefix(r"C:\Users\metadata", r"C:\Users\me"),
                 None
+            );
+            // Drive-root home with a trailing separator still strips.
+            assert_eq!(
+                strip_home_prefix(r"D:\code\app", r"D:\"),
+                Some(r"code\app".to_owned()),
             );
         }
     }

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -23,8 +23,10 @@ use crate::model::{Collection, DurationEvent, ScanStats, SessionTouch, ToolEvent
 const CACHE_VERSION: u32 = 7;
 
 /// Normalize a working-directory path into a project label: strip the home
-/// prefix, keep the real path separators ("/Users/me/code/app" -> "code/app",
-/// "C:\\Users\\me\\code\\app" -> "code\\app"). A session whose cwd is exactly
+/// prefix and (on Windows) normalize separators to `/` so the same repo
+/// collapses to one project key regardless of native (`\`) vs npm/Node-style
+/// (`/`) cwd. "/Users/me/code/app" -> "code/app",
+/// "C:\\Users\\me\\code\\app" -> "code/app". A session whose cwd is exactly
 /// the home directory renders as "~" rather than an empty label so the
 /// PROJECTS row has something readable.
 pub fn project_from_cwd(cwd: &str) -> String {
@@ -72,7 +74,11 @@ fn strip_home_prefix(cwd: &str, home: &str) -> Option<String> {
     if !rest.is_empty() && !rest.starts_with(['/', '\\']) {
         return None;
     }
-    Some(rest.trim_start_matches(['/', '\\']).to_owned())
+    // Normalize backslashes to forward slashes in the remainder so the same
+    // repository visited as `C:\Users\me\code\app` (native) and
+    // `C:/Users/me/code/app` (npm/Node tooling) collapses to one project key
+    // (`code/app`) instead of splitting the totals across two labels.
+    Some(rest.trim_start_matches(['/', '\\']).replace('\\', "/"))
 }
 
 /// Same shape on Unix: require a path-component boundary so that home
@@ -490,19 +496,21 @@ mod tests {
         // Windows-only test: case-insensitive prefix match with separator
         // normalization and boundary check.
         if cfg!(windows) {
-            assert_eq!(
-                strip_home_prefix(r"C:\Users\me\code\app", r"C:\Users\me"),
-                Some(r"code\app".to_owned()),
-            );
-            // Lowercase drive letter still strips.
+            // Lowercase drive letter still strips, remainder normalized.
             assert_eq!(
                 strip_home_prefix(r"c:\users\me\code\app", r"C:\Users\me"),
-                Some(r"code\app".to_owned()),
+                Some("code/app".to_owned()),
             );
             // Mixed separators (forward-slashed cwd from npm/Node tooling,
-            // backslashed home from dirs::home_dir).
+            // backslashed home from dirs::home_dir) — and the remainder is
+            // returned with normalized forward slashes so a native-style
+            // visit to the same repo also lands at `code/app`, not `code\app`.
             assert_eq!(
                 strip_home_prefix("C:/Users/me/code/app", r"C:\Users\me"),
+                Some("code/app".to_owned()),
+            );
+            assert_eq!(
+                strip_home_prefix(r"C:\Users\me\code\app", r"C:\Users\me"),
                 Some("code/app".to_owned()),
             );
             // Non-boundary sibling does not strip.
@@ -510,10 +518,11 @@ mod tests {
                 strip_home_prefix(r"C:\Users\metadata", r"C:\Users\me"),
                 None
             );
-            // Drive-root home with a trailing separator still strips.
+            // Drive-root home with a trailing separator still strips (and
+            // the remainder is normalized to forward slashes).
             assert_eq!(
                 strip_home_prefix(r"D:\code\app", r"D:\"),
-                Some(r"code\app".to_owned()),
+                Some("code/app".to_owned()),
             );
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ mod cost;
 mod demo;
 mod format;
 mod model;
+mod paths;
 mod share;
 mod ui;
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -20,10 +20,14 @@ pub fn cache_dir() -> Result<PathBuf> {
     Ok(home_dir()?.join(".cache").join("agent-walker"))
 }
 
-/// Default save directory for the share card. Prefers `<home>/Downloads` when
-/// it exists, otherwise the home directory itself.
+/// Default save directory for the share card. `dirs::download_dir` consults
+/// the OS-native location (Known Folders on Windows, `NSDownloadsDirectory`
+/// on macOS, XDG on Linux), so a non-English or relocated Downloads folder
+/// still resolves correctly. Falls back to the home directory when the OS
+/// doesn't report a Downloads location.
 pub fn downloads_dir() -> Result<PathBuf> {
     let home = home_dir()?;
-    let downloads = home.join("Downloads");
-    Ok(if downloads.is_dir() { downloads } else { home })
+    Ok(dirs::download_dir()
+        .filter(|path| path.is_dir())
+        .unwrap_or(home))
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,0 +1,29 @@
+//! Cross-platform path helpers. All home / cache / downloads resolution goes
+//! through here so a switch from `HOME` to `dirs::*` happens once, and Windows
+//! and Unix share the same code path.
+
+use std::path::PathBuf;
+
+use anyhow::{Result, anyhow};
+
+/// The user's home directory. `dirs::home_dir` consults `$HOME` on Unix and
+/// `%USERPROFILE%` on Windows.
+pub fn home_dir() -> Result<PathBuf> {
+    dirs::home_dir().ok_or_else(|| anyhow!("could not locate the user home directory"))
+}
+
+/// Base directory for `agent-walker`'s parse cache. Stays at
+/// `<home>/.cache/agent-walker` on every platform so a macOS/Linux user
+/// upgrading does not lose their warmed cache; on Windows this resolves under
+/// `%USERPROFILE%\.cache\agent-walker`.
+pub fn cache_dir() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".cache").join("agent-walker"))
+}
+
+/// Default save directory for the share card. Prefers `<home>/Downloads` when
+/// it exists, otherwise the home directory itself.
+pub fn downloads_dir() -> Result<PathBuf> {
+    let home = home_dir()?;
+    let downloads = home.join("Downloads");
+    Ok(if downloads.is_dir() { downloads } else { home })
+}

--- a/src/share/actions.rs
+++ b/src/share/actions.rs
@@ -6,15 +6,13 @@ use anyhow::{Context, Result};
 use super::card::ShareCard;
 use super::raster::{render_pixmap, render_png};
 
-/// Default path for a saved card: `~/Downloads/agent-walker.png`, falling back
-/// to the home directory if there's no Downloads folder.
+/// Default path for a saved card: `<home>/Downloads/agent-walker.png`, falling
+/// back to the home directory if there's no Downloads folder. Resolves through
+/// `paths::downloads_dir` so Windows and Unix share the same code path.
 pub fn default_save_path() -> PathBuf {
-    let home = std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_default();
-    let downloads = home.join("Downloads");
-    let dir = if downloads.is_dir() { downloads } else { home };
-    dir.join("agent-walker.png")
+    crate::paths::downloads_dir()
+        .unwrap_or_default()
+        .join("agent-walker.png")
 }
 
 /// Write the card PNG to `path`.


### PR DESCRIPTION
## Summary

agent-walker now runs on Windows. The dashboard reads logs under `%USERPROFILE%`
(`.claude\projects`, `.codex\sessions`, `.gemini\antigravity-cli`), and we ship
a prebuilt Windows binary alongside the existing macOS / Linux ones via the
same `npx agent-walker` / `bunx agent-walker` install path. WSL keeps working
unchanged.

## Changes

- New `src/paths.rs` built on `dirs::home_dir` — home / cache / downloads
  resolution lives in one place, no part of the codebase reads `HOME` directly
  anymore.
- The five sites that used to read `HOME` (default log dirs, cache, share-card
  save path, project label, Claude project name) all route through it.
- `project_from_cwd` strips the home prefix case-insensitively on Windows
  (matching the case-insensitive filesystem), requires a path-component
  boundary so `C:\Users\metadata` doesn't get clipped against home
  `C:\Users\me`, and uses `cwd.get(..home.len())` so a multi-byte UTF-8 cwd
  cannot panic.
- `dist-workspace.toml` builds `x86_64-pc-windows-msvc`; `.github/workflows/ci.yml`
  adds `windows-latest` to the test matrix, so regressions surface on PRs.
- README (EN + JA), CHANGELOG, and Cargo bumped to 0.3.0.

## Test

- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo test` — 43 passing (two new regression tests for `strip_home_prefix`,
  one Unix-gated and one Windows-gated via `cfg!(windows)`).
- Cross-model review through `sk:codex-cli` — first pass flagged a
  case-sensitivity bug and a multi-byte panic, both fixed; the third pass
  returned `fix verified`.
- True Windows behavior is exercised by the new `windows-latest` CI job below.