### PR TITLE
Honor CODEX_HOME and CLAUDE_CONFIG_DIR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `%USERPROFILE%` (`.claude\projects`, `.codex\sessions`,
   `.gemini\antigravity-cli`).
 - CI now exercises `cargo test` on `windows-latest` alongside macOS and Linux.
+- Honor `CODEX_HOME` (Codex CLI's official override) and `CLAUDE_CONFIG_DIR`
+  (Claude Code's de-facto override) so users with relocated agent state still
+  see their usage instead of a blank dashboard.
 
 ### Changed
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,7 @@ bunx agent-walker
 | `--share <path>` | カードを PNG 出力＋キャプション表示して終了 |
 | `--agy` | Antigravity も読む（既定オフ） |
 | `--no-cache` | パースキャッシュを無視して全再走査 |
-| `--claude-dir` / `--codex-dir` / `--agy-dir` | 非標準のログ場所を指定 |
+| `--claude-dir` / `--codex-dir` / `--agy-dir` | 非標準のログ場所を指定（`CLAUDE_CONFIG_DIR` / `CODEX_HOME` も自動で読む） |
 | `--completions <shell>` | シェル補完を出力して終了 |
 
 ## codename を共有

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Flags:
 | `--share <path>` | Render the stats card to a PNG, print its caption, and exit |
 | `--agy` | Also scan Antigravity logs (off by default — see [What it reads](#what-it-reads)) |
 | `--no-cache` | Rescan every log file, ignoring the parse cache |
-| `--claude-dir` / `--codex-dir` / `--agy-dir` | Point at non-standard log locations |
+| `--claude-dir` / `--codex-dir` / `--agy-dir` | Point at non-standard log locations (also honors `CLAUDE_CONFIG_DIR` and `CODEX_HOME` when set) |
 | `--completions <shell>` | Print shell completions (e.g. `--completions zsh`) and exit |
 
 ## Share your codename

--- a/src/app.rs
+++ b/src/app.rs
@@ -82,7 +82,10 @@ pub struct Config {
     pub demo: bool,
     pub claude_dir: PathBuf,
     pub codex_dir: PathBuf,
-    pub agy_dir: PathBuf,
+    /// Resolved only when `agy` is on. Skipping the home/default lookup here
+    /// lets agent-walker still start in environments where `dirs::home_dir()`
+    /// can't resolve, as long as the user isn't asking for Antigravity data.
+    pub agy_dir: Option<PathBuf>,
     /// Antigravity collection is opt-in (`--agy`); off by default because the
     /// logs carry no token usage.
     pub agy: bool,
@@ -116,7 +119,14 @@ pub fn run(args: Args) -> Result<()> {
         // circuit before the CLI override ever got a chance.
         claude_dir: args.claude_dir.map_or_else(default_claude_dir, Ok)?,
         codex_dir: args.codex_dir.map_or_else(default_codex_dir, Ok)?,
-        agy_dir: args.agy_dir.map_or_else(default_agy_dir, Ok)?,
+        // agy is opt-in via --agy; if it's off we never need agy_dir, so
+        // skip the home lookup entirely. A --agy-dir without --agy is
+        // preserved verbatim (cheap, no resolution) but ignored downstream.
+        agy_dir: if args.agy {
+            Some(args.agy_dir.map_or_else(default_agy_dir, Ok)?)
+        } else {
+            args.agy_dir
+        },
         agy: args.agy,
         days: args.days,
         use_cache: !args.no_cache,
@@ -221,14 +231,13 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
         // Antigravity is opt-in (`--agy`): its logs carry no token usage, so it
         // is left out of the default report rather than skewing the totals.
         let agy_handle = scope.spawn(|| {
-            config.agy.then(|| {
-                agy::collect(
-                    &config.agy_dir,
-                    mtime_floor,
-                    config.use_cache,
-                    config.local_offset,
-                )
-            })
+            // `config.agy` and `config.agy_dir` agree by construction: when
+            // `agy` is true `agy_dir` is `Some`; when it's false we skip both.
+            config
+                .agy
+                .then(|| config.agy_dir.as_ref())
+                .flatten()
+                .map(|dir| agy::collect(dir, mtime_floor, config.use_cache, config.local_offset))
         });
         let claude_collection = claude::collect(
             &config.claude_dir,

--- a/src/app.rs
+++ b/src/app.rs
@@ -235,7 +235,7 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
             // `agy` is true `agy_dir` is `Some`; when it's false we skip both.
             config
                 .agy
-                .then(|| config.agy_dir.as_ref())
+                .then_some(config.agy_dir.as_ref())
                 .flatten()
                 .map(|dir| agy::collect(dir, mtime_floor, config.use_cache, config.local_offset))
         });

--- a/src/app.rs
+++ b/src/app.rs
@@ -109,9 +109,14 @@ pub fn run(args: Args) -> Result<()> {
     let local_offset = UtcOffset::current_local_offset().unwrap_or(UtcOffset::UTC);
     let config = Config {
         demo: demo_enabled(),
-        claude_dir: args.claude_dir.unwrap_or(default_claude_dir()?),
-        codex_dir: args.codex_dir.unwrap_or(default_codex_dir()?),
-        agy_dir: args.agy_dir.unwrap_or(default_agy_dir()?),
+        // `map_or_else(default, Ok)` keeps the default lazy, so a `--claude-dir`
+        // / `--codex-dir` / `--agy-dir` override on the CLI still works even
+        // when `dirs::home_dir()` can't resolve (sandbox / no `$HOME` /
+        // `%USERPROFILE%`). Eagerly calling `default_*_dir()?` would short-
+        // circuit before the CLI override ever got a chance.
+        claude_dir: args.claude_dir.map_or_else(default_claude_dir, Ok)?,
+        codex_dir: args.codex_dir.map_or_else(default_codex_dir, Ok)?,
+        agy_dir: args.agy_dir.map_or_else(default_agy_dir, Ok)?,
         agy: args.agy,
         days: args.days,
         use_cache: !args.no_cache,

--- a/src/app.rs
+++ b/src/app.rs
@@ -263,17 +263,15 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
 }
 
 fn default_claude_dir() -> Result<PathBuf> {
-    Ok(crate::paths::home_dir()?.join(".claude").join("projects"))
+    Ok(crate::paths::claude_home()?.join("projects"))
 }
 
 fn default_codex_dir() -> Result<PathBuf> {
-    Ok(crate::paths::home_dir()?.join(".codex").join("sessions"))
+    Ok(crate::paths::codex_home()?.join("sessions"))
 }
 
 fn default_agy_dir() -> Result<PathBuf> {
-    Ok(crate::paths::home_dir()?
-        .join(".gemini")
-        .join("antigravity-cli"))
+    crate::paths::agy_home()
 }
 
 fn demo_enabled() -> bool {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,8 +1,14 @@
 //! Cross-platform path helpers. All home / cache / downloads resolution goes
 //! through here so a switch from `HOME` to `dirs::*` happens once, and Windows
 //! and Unix share the same code path.
+//!
+//! Per-tool roots can be overridden by an environment variable so users with a
+//! relocated config (multi-account setups, repos on a different drive on
+//! Windows) don't end up with a blank dashboard. The variables we honor are
+//! the ones each tool itself reads; see `claude_home` / `codex_home` for the
+//! per-tool notes.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
 
@@ -10,6 +16,49 @@ use anyhow::{Result, anyhow};
 /// `%USERPROFILE%` on Windows.
 pub fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().ok_or_else(|| anyhow!("could not locate the user home directory"))
+}
+
+/// Pure helper: if `env_value` is `Some` use it as the root, otherwise fall
+/// back to `home.join(fallback_subdir)`. Split out so the env logic can be
+/// tested without mutating process environment variables.
+fn resolve_root(env_value: Option<&str>, home: &Path, fallback_subdir: &str) -> PathBuf {
+    match env_value {
+        Some(value) if !value.is_empty() => PathBuf::from(value),
+        _ => home.join(fallback_subdir),
+    }
+}
+
+/// Root directory Claude Code reads. Defaults to `~/.claude`.
+///
+/// `CLAUDE_CONFIG_DIR` overrides it if set — Anthropic has not officially
+/// documented this variable as of 2026-06 (it's a recurring feature request),
+/// but Claude Code does read it in practice. We honor it best-effort so
+/// agent-walker doesn't disagree with users who relocate their config; if
+/// Anthropic ever changes the contract we simply fall back to `~/.claude`.
+pub fn claude_home() -> Result<PathBuf> {
+    Ok(resolve_root(
+        std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(),
+        &home_dir()?,
+        ".claude",
+    ))
+}
+
+/// Root directory Codex CLI reads. Defaults to `~/.codex`.
+///
+/// `CODEX_HOME` overrides it if set — this is the official variable
+/// documented at <https://developers.openai.com/codex/environment-variables>.
+pub fn codex_home() -> Result<PathBuf> {
+    Ok(resolve_root(
+        std::env::var("CODEX_HOME").ok().as_deref(),
+        &home_dir()?,
+        ".codex",
+    ))
+}
+
+/// Root directory Antigravity CLI reads. No env override is known; the value
+/// is `~/.gemini/antigravity-cli`.
+pub fn agy_home() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".gemini").join("antigravity-cli"))
 }
 
 /// Base directory for `agent-walker`'s parse cache. Stays at
@@ -30,4 +79,39 @@ pub fn downloads_dir() -> Result<PathBuf> {
     Ok(dirs::download_dir()
         .filter(|path| path.is_dir())
         .unwrap_or(home))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_root_uses_env_when_set() {
+        let home = PathBuf::from("/home/me");
+        assert_eq!(
+            resolve_root(Some("/srv/codex"), &home, ".codex"),
+            PathBuf::from("/srv/codex"),
+        );
+    }
+
+    #[test]
+    fn resolve_root_falls_back_to_home_when_env_missing() {
+        let home = PathBuf::from("/home/me");
+        assert_eq!(
+            resolve_root(None, &home, ".codex"),
+            PathBuf::from("/home/me/.codex"),
+        );
+    }
+
+    #[test]
+    fn resolve_root_treats_empty_env_as_unset() {
+        // An empty value is almost always a misconfigured env (`CODEX_HOME=`
+        // in a shell script clears it); treat it like unset rather than
+        // pointing the tool at the current working directory.
+        let home = PathBuf::from("/home/me");
+        assert_eq!(
+            resolve_root(Some(""), &home, ".codex"),
+            PathBuf::from("/home/me/.codex"),
+        );
+    }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -8,6 +8,7 @@
 //! the ones each tool itself reads; see `claude_home` / `codex_home` for the
 //! per-tool notes.
 
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
@@ -22,9 +23,11 @@ pub fn home_dir() -> Result<PathBuf> {
 /// otherwise call `fallback()`. The fallback is lazy so `home_dir()` (which
 /// can itself fail) is never invoked when an env override is in effect — that
 /// lets a user with no resolvable home still point agent-walker at their
-/// relocated agent state via the env variable. Split out so the env logic can
-/// be tested without mutating process environment variables.
-fn resolve_root<F>(env_value: Option<&str>, fallback: F) -> Result<PathBuf>
+/// relocated agent state via the env variable. Takes an `OsString` (not a
+/// `String`) so a path with non-UTF-8 bytes — legal on Unix — round-trips
+/// instead of being silently dropped. Split out so the env logic can be
+/// tested without mutating process environment variables.
+fn resolve_root<F>(env_value: Option<OsString>, fallback: F) -> Result<PathBuf>
 where
     F: FnOnce() -> Result<PathBuf>,
 {
@@ -42,7 +45,7 @@ where
 /// agent-walker doesn't disagree with users who relocate their config; if
 /// Anthropic ever changes the contract we simply fall back to `~/.claude`.
 pub fn claude_home() -> Result<PathBuf> {
-    resolve_root(std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(), || {
+    resolve_root(std::env::var_os("CLAUDE_CONFIG_DIR"), || {
         Ok(home_dir()?.join(".claude"))
     })
 }
@@ -52,7 +55,7 @@ pub fn claude_home() -> Result<PathBuf> {
 /// `CODEX_HOME` overrides it if set — this is the official variable
 /// documented at <https://developers.openai.com/codex/environment-variables>.
 pub fn codex_home() -> Result<PathBuf> {
-    resolve_root(std::env::var("CODEX_HOME").ok().as_deref(), || {
+    resolve_root(std::env::var_os("CODEX_HOME"), || {
         Ok(home_dir()?.join(".codex"))
     })
 }
@@ -92,7 +95,9 @@ mod tests {
         // The closure must NOT run when an env override is in effect — that's
         // what lets users with an unresolvable home still point us at their
         // relocated state via `CODEX_HOME` / `CLAUDE_CONFIG_DIR`.
-        let result = resolve_root(Some("/srv/codex"), || panic!("fallback must not be called"));
+        let result = resolve_root(Some(OsString::from("/srv/codex")), || {
+            panic!("fallback must not be called")
+        });
         assert_eq!(result.unwrap(), PathBuf::from("/srv/codex"));
     }
 
@@ -107,7 +112,9 @@ mod tests {
         // An empty value is almost always a misconfigured env (`CODEX_HOME=`
         // in a shell script clears it); treat it like unset rather than
         // pointing the tool at the current working directory.
-        let result = resolve_root(Some(""), || Ok(PathBuf::from("/home/me/.codex")));
+        let result = resolve_root(Some(OsString::new()), || {
+            Ok(PathBuf::from("/home/me/.codex"))
+        });
         assert_eq!(result.unwrap(), PathBuf::from("/home/me/.codex"));
     }
 
@@ -115,5 +122,20 @@ mod tests {
     fn resolve_root_propagates_fallback_error() {
         let result: Result<PathBuf> = resolve_root(None, || Err(anyhow!("home not found")));
         assert!(result.is_err());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve_root_preserves_non_utf8_env_path() {
+        // Unix paths can contain non-UTF-8 bytes. The earlier `env::var`-based
+        // path silently dropped these into the fallback; `env::var_os` round-
+        // trips them so the override still wins.
+        use std::os::unix::ffi::OsStringExt;
+        let bytes = vec![b'/', b't', b'm', b'p', b'/', 0xff, 0xfe, b'/', b'x'];
+        let raw = OsString::from_vec(bytes.clone());
+        let result = resolve_root(Some(raw.clone()), || {
+            panic!("fallback must not be called for a non-UTF-8 path")
+        });
+        assert_eq!(result.unwrap(), PathBuf::from(raw));
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -8,7 +8,7 @@
 //! the ones each tool itself reads; see `claude_home` / `codex_home` for the
 //! per-tool notes.
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
 use anyhow::{Result, anyhow};
 
@@ -18,13 +18,19 @@ pub fn home_dir() -> Result<PathBuf> {
     dirs::home_dir().ok_or_else(|| anyhow!("could not locate the user home directory"))
 }
 
-/// Pure helper: if `env_value` is `Some` use it as the root, otherwise fall
-/// back to `home.join(fallback_subdir)`. Split out so the env logic can be
-/// tested without mutating process environment variables.
-fn resolve_root(env_value: Option<&str>, home: &Path, fallback_subdir: &str) -> PathBuf {
+/// Pure helper: if `env_value` is a non-empty `Some` use it as the root,
+/// otherwise call `fallback()`. The fallback is lazy so `home_dir()` (which
+/// can itself fail) is never invoked when an env override is in effect — that
+/// lets a user with no resolvable home still point agent-walker at their
+/// relocated agent state via the env variable. Split out so the env logic can
+/// be tested without mutating process environment variables.
+fn resolve_root<F>(env_value: Option<&str>, fallback: F) -> Result<PathBuf>
+where
+    F: FnOnce() -> Result<PathBuf>,
+{
     match env_value {
-        Some(value) if !value.is_empty() => PathBuf::from(value),
-        _ => home.join(fallback_subdir),
+        Some(value) if !value.is_empty() => Ok(PathBuf::from(value)),
+        _ => fallback(),
     }
 }
 
@@ -36,11 +42,9 @@ fn resolve_root(env_value: Option<&str>, home: &Path, fallback_subdir: &str) -> 
 /// agent-walker doesn't disagree with users who relocate their config; if
 /// Anthropic ever changes the contract we simply fall back to `~/.claude`.
 pub fn claude_home() -> Result<PathBuf> {
-    Ok(resolve_root(
-        std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(),
-        &home_dir()?,
-        ".claude",
-    ))
+    resolve_root(std::env::var("CLAUDE_CONFIG_DIR").ok().as_deref(), || {
+        Ok(home_dir()?.join(".claude"))
+    })
 }
 
 /// Root directory Codex CLI reads. Defaults to `~/.codex`.
@@ -48,11 +52,9 @@ pub fn claude_home() -> Result<PathBuf> {
 /// `CODEX_HOME` overrides it if set — this is the official variable
 /// documented at <https://developers.openai.com/codex/environment-variables>.
 pub fn codex_home() -> Result<PathBuf> {
-    Ok(resolve_root(
-        std::env::var("CODEX_HOME").ok().as_deref(),
-        &home_dir()?,
-        ".codex",
-    ))
+    resolve_root(std::env::var("CODEX_HOME").ok().as_deref(), || {
+        Ok(home_dir()?.join(".codex"))
+    })
 }
 
 /// Root directory Antigravity CLI reads. No env override is known; the value
@@ -86,21 +88,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn resolve_root_uses_env_when_set() {
-        let home = PathBuf::from("/home/me");
-        assert_eq!(
-            resolve_root(Some("/srv/codex"), &home, ".codex"),
-            PathBuf::from("/srv/codex"),
-        );
+    fn resolve_root_uses_env_when_set_without_touching_fallback() {
+        // The closure must NOT run when an env override is in effect — that's
+        // what lets users with an unresolvable home still point us at their
+        // relocated state via `CODEX_HOME` / `CLAUDE_CONFIG_DIR`.
+        let result = resolve_root(Some("/srv/codex"), || panic!("fallback must not be called"));
+        assert_eq!(result.unwrap(), PathBuf::from("/srv/codex"));
     }
 
     #[test]
-    fn resolve_root_falls_back_to_home_when_env_missing() {
-        let home = PathBuf::from("/home/me");
-        assert_eq!(
-            resolve_root(None, &home, ".codex"),
-            PathBuf::from("/home/me/.codex"),
-        );
+    fn resolve_root_falls_back_when_env_missing() {
+        let result = resolve_root(None, || Ok(PathBuf::from("/home/me/.codex")));
+        assert_eq!(result.unwrap(), PathBuf::from("/home/me/.codex"));
     }
 
     #[test]
@@ -108,10 +107,13 @@ mod tests {
         // An empty value is almost always a misconfigured env (`CODEX_HOME=`
         // in a shell script clears it); treat it like unset rather than
         // pointing the tool at the current working directory.
-        let home = PathBuf::from("/home/me");
-        assert_eq!(
-            resolve_root(Some(""), &home, ".codex"),
-            PathBuf::from("/home/me/.codex"),
-        );
+        let result = resolve_root(Some(""), || Ok(PathBuf::from("/home/me/.codex")));
+        assert_eq!(result.unwrap(), PathBuf::from("/home/me/.codex"));
+    }
+
+    #[test]
+    fn resolve_root_propagates_fallback_error() {
+        let result: Result<PathBuf> = resolve_root(None, || Err(anyhow!("home not found")));
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
## Summary

Pick up two per-tool environment overrides so users with a relocated agent state still see their usage instead of a blank dashboard.

- `CODEX_HOME` — Codex CLI's [officially-documented](https://developers.openai.com/codex/environment-variables) env that moves sessions, config, logs, auth, etc. off `~/.codex`.
- `CLAUDE_CONFIG_DIR` — Claude Code's de-facto override. Anthropic has not officially documented it yet, but the CLI does read it; we honor it best-effort and fall back to `~/.claude` if it ever stops working.

`agy` has no known env override; left as `~/.gemini/antigravity-cli`.

## Changes

- New `paths::claude_home()` / `paths::codex_home()` consolidate the env-or-home decision; `app.rs::default_*_dir` route through them.
- A pure `resolve_root(env, home, fallback)` keeps the env logic testable without mutating process env.
- README (EN + JA) and CHANGELOG mention the new behaviour.

## Test

`cargo clippy --all-targets -- -D warnings` clean. `cargo test` — 47 passing (three new tests for `resolve_root`).