### PR TITLE
Add a 3-day cooldown to Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    # Wait three days before opening a PR for a fresh release. A brand-new
+    # version is the riskiest window for a typosquat or a compromised
+    # publish (the `xz-utils` style of incident); this gives the ecosystem
+    # time to flag it before it lands here. Major bumps wait a week.
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
     groups:
       minor-and-patch:
         update-types: ["minor", "patch"]
@@ -11,3 +18,5 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## Summary

Wait three days (seven for major bumps) before Dependabot opens a PR for a fresh dependency release. A brand-new version is the riskiest window — typosquats and compromised publishes (the `xz-utils`-style incident) tend to be flagged within the first day or two — so cooling off gives the ecosystem time to raise the alarm before the update lands here.

## Changes

- `.github/dependabot.yml` — add `cooldown.default-days: 3` to both the `cargo` and `github-actions` ecosystems, plus `semver-major-days: 7` on the cargo side.

## Test

Config-only change; nothing to build or test locally. GitHub validates the schema when the file lands on `main`.