### PR TITLE
Add OpenCode provider (local SQLite collector)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - OpenCode support. Its local SQLite store (`~/.local/share/opencode`, or
-  `$OPENCODE_HOME` / `$XDG_DATA_HOME`) is auto-detected and read via a read-only
-  in-memory snapshot (SQLite's Backup API — never locks or writes your live
-  store), contributing tokens, models, tools, projects, durations, and activity
-  — near parity with Claude and Codex. Follows OpenCode's own resolver:
-  `OPENCODE_DB` overrides the file, and per-channel `opencode-<channel>.db`
-  stores are picked up alongside the default. `--opencode-dir` points at a
-  non-standard data dir.
+  `$OPENCODE_HOME` / `$XDG_DATA_HOME`) is auto-detected and read **read-only**
+  (never locks, checkpoints, or writes your live store), contributing tokens,
+  models, tools, projects, durations, and activity — near parity with Claude and
+  Codex. Follows OpenCode's own resolver: `OPENCODE_DB` overrides the file, and
+  per-channel `opencode-<channel>.db` stores are picked up alongside the default
+  (deduped by row id). Reasoning tokens are folded into the output total.
+  `--opencode-dir` points at a non-standard data dir.
 
 ## [0.4.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-06-23
 
 ### Added
 
@@ -111,6 +111,7 @@ First public release with the codename system and the shareable stats card.
 
 Initial npm packaging.
 
+[0.5.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.5.0
 [0.4.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.4.0
 [0.3.1]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.3.1
 [0.3.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- OpenCode support. Its local SQLite store (`~/.local/share/opencode/opencode.db`,
+  or `$OPENCODE_HOME` / `$XDG_DATA_HOME`) is auto-detected and read **read-only**,
+  contributing tokens, models, tools, projects, durations, and activity — near
+  parity with Claude and Codex. `--opencode-dir` points at a non-standard
+  location.
+
 ## [0.4.0] - 2026-06-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- OpenCode support. Its local SQLite store (`~/.local/share/opencode/opencode.db`,
-  or `$OPENCODE_HOME` / `$XDG_DATA_HOME`) is auto-detected and read **read-only**,
-  contributing tokens, models, tools, projects, durations, and activity — near
-  parity with Claude and Codex. `--opencode-dir` points at a non-standard
-  location.
+- OpenCode support. Its local SQLite store (`~/.local/share/opencode`, or
+  `$OPENCODE_HOME` / `$XDG_DATA_HOME`) is auto-detected and read via a read-only
+  in-memory snapshot (SQLite's Backup API — never locks or writes your live
+  store), contributing tokens, models, tools, projects, durations, and activity
+  — near parity with Claude and Codex. Follows OpenCode's own resolver:
+  `OPENCODE_DB` overrides the file, and per-channel `opencode-<channel>.db`
+  stores are picked up alongside the default. `--opencode-dir` points at a
+  non-standard data dir.
 
 ## [0.4.0] - 2026-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-walker"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "ratatui",
  "rayon",
  "resvg",
+ "rusqlite",
  "serde",
  "serde_json",
  "tempfile",
@@ -29,6 +30,18 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ureq",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -644,6 +657,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,6 +903,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -905,6 +939,15 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
 ]
 
 [[package]]
@@ -1190,6 +1233,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -1658,6 +1712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1979,6 +2039,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.13.0",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -2785,6 +2859,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,10 @@ tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 resvg = "0.47"
 arboard = "3.6.1"
+# Read a private snapshot copy of OpenCode's live SQLite store (collector/opencode).
+tempfile = "3.24.0"
 
 [dev-dependencies]
-tempfile = "3.24.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-walker"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.93"
 description = "Local AI coding-agent usage dashboard — tokens, cost, projects, autonomy."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ crossterm = "0.29.0"
 dirs = "5.0.1"
 ratatui = "0.30.1"
 rayon = "1.11.0"
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 ureq = "2.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossterm = "0.29.0"
 dirs = "5.0.1"
 ratatui = "0.30.1"
 rayon = "1.11.0"
-rusqlite = { version = "0.32.1", features = ["bundled", "backup"] }
+rusqlite = { version = "0.32.1", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 ureq = "2.12.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ crossterm = "0.29.0"
 dirs = "5.0.1"
 ratatui = "0.30.1"
 rayon = "1.11.0"
-rusqlite = { version = "0.32.1", features = ["bundled"] }
+rusqlite = { version = "0.32.1", features = ["bundled", "backup"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 ureq = "2.12.1"
@@ -38,10 +38,10 @@ tracing = "0.1.43"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 resvg = "0.47"
 arboard = "3.6.1"
-# Read a private snapshot copy of OpenCode's live SQLite store (collector/opencode).
-tempfile = "3.24.0"
 
 [dev-dependencies]
+# OpenCode collector tests build throwaway SQLite fixtures in a temp dir.
+tempfile = "3.24.0"
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ card — just glance before you post.
 |---|---|---|
 | Claude Code | `~/.claude/projects/**/*.jsonl` | tokens, models, tools, subagents, projects, turn durations — [details](docs/claude.md) |
 | Codex CLI | `~/.codex/sessions/**/*.jsonl` | tokens, models, tools, task durations, projects — [details](docs/codex.md) |
-| OpenCode | `~/.local/share/opencode/opencode.db` | auto-detected (SQLite, read-only); tokens, models, tools, durations, projects — [details](docs/opencode.md) |
+| OpenCode | `~/.local/share/opencode/opencode*.db` | auto-detected (SQLite, read-only snapshot; honors `OPENCODE_DB`); tokens, models, tools, durations, projects — [details](docs/opencode.md) |
 | Antigravity CLI | `~/.gemini/antigravity-cli` | auto-detected (tab shows only if logs exist); sessions and tool flow only — no token data in its logs — [details](docs/agy.md) |
 
 Each agent counts and caches tokens differently. The per-agent pages above

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Flags:
 | `--days <N>` | Analysis window for the graphs (default 30; the codename's throughput level is always taken from the last 30 days, so the rank doesn't drift with `--days`) |
 | `--share <path>` | Render the stats card to a PNG, print its caption, and exit |
 | `--no-cache` | Rescan every log file, ignoring the parse cache |
-| `--claude-dir` / `--codex-dir` / `--agy-dir` | Point at non-standard log locations (also honors `CLAUDE_CONFIG_DIR` and `CODEX_HOME` when set) |
+| `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` | Point at non-standard log locations (also honors `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, and `OPENCODE_HOME` when set) |
 | `--completions <shell>` | Print shell completions (e.g. `--completions zsh`) and exit |
 
 ## Share your codename
@@ -95,6 +95,7 @@ card — just glance before you post.
 |---|---|---|
 | Claude Code | `~/.claude/projects/**/*.jsonl` | tokens, models, tools, subagents, projects, turn durations — [details](docs/claude.md) |
 | Codex CLI | `~/.codex/sessions/**/*.jsonl` | tokens, models, tools, task durations, projects — [details](docs/codex.md) |
+| OpenCode | `~/.local/share/opencode/opencode.db` | auto-detected (SQLite, read-only); tokens, models, tools, durations, projects — [details](docs/opencode.md) |
 | Antigravity CLI | `~/.gemini/antigravity-cli` | auto-detected (tab shows only if logs exist); sessions and tool flow only — no token data in its logs — [details](docs/agy.md) |
 
 Each agent counts and caches tokens differently. The per-agent pages above

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+# Proper nouns / product names that `clippy::doc_markdown` must not flag as
+# un-backticked code identifiers. `..` keeps clippy's built-in allowlist.
+doc-valid-idents = ["OpenCode", "Ollama", "SQLite", "LiteLLM", ".."]

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -1,0 +1,47 @@
+# OpenCode
+
+## Where the data comes from
+
+`~/.local/share/opencode/opencode.db` — a local SQLite store (overridable with
+`OPENCODE_HOME`, or `$XDG_DATA_HOME/opencode`). Read-only and **immutable**, so
+agent-walker never locks the DB, never recovers its WAL, and never writes to your
+OpenCode store. Storage location is documented at
+[opencode.ai/docs/troubleshooting](https://opencode.ai/docs/troubleshooting/);
+the schema lives in the OSS repo (`sst/opencode`). Auto-detected: the OpenCode
+tab appears only when `opencode.db` exists.
+
+## What's captured
+
+- **Token usage** per assistant message, from the `message` table's `data` JSON
+  (`tokens.input` / `output` / `reasoning` / `cache.read` / `cache.write`). Mapped
+  to the same schema as Claude / Codex:
+
+  ```
+  tokens = input + output + cache_read + cache_creation(=cache.write)
+  ```
+
+- **Model** from `data.modelID` (e.g. `qwen3:8b`, `claude-...`).
+- **Project** from `data.path.cwd` (the working directory), labeled like the other
+  providers.
+- **Durations** from `data.time.created` → `time.completed` per assistant message
+  → the COMPLETION section.
+- **Tools** from `part` rows of `type:"tool"` (the `tool` field: `glob` / `read` /
+  `edit` / `bash` / an MCP name).
+- **Sessions / activity / hourly** from message timestamps (`time.created`).
+
+So OpenCode reaches near-parity with Claude / Codex: tokens, cost, model,
+project, tools, sessions, durations, and hourly — all from the local DB.
+
+## Cost
+
+Same cache-aware, API-equivalent formula as the other providers: priced from the
+LiteLLM database by model name. OpenCode also records its own per-message `cost`,
+but agent-walker ignores it for consistency. Local models (e.g. Ollama) aren't in
+the pricing database, so their cost shows as $0 even though their tokens count.
+
+## Caveats
+
+- Only `opencode.db` is read; per-channel stores (`opencode-<channel>.db`) are
+  not, for now.
+- Immutable reads see the last-committed state, so a session still being written
+  may lag by one checkpoint.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -13,11 +13,12 @@ follows OpenCode's own database resolver:
   default `opencode.db` and the `opencode-<channel>.db` a non-stable install
   (e.g. a `dev` build) writes.
 
-It opens each DB **read-only** and takes a consistent snapshot through SQLite's
-online **Backup API** (an in-memory copy under SQLite's read lock), then reads
-from that copy — so it never locks, checkpoints, writes, or corrupts your live
-store, and there's no file-copy race between the DB and its WAL. Storage location
-is documented at
+It opens each DB **read-only** and reads it directly. The read-only flag means
+SQLite can't write, checkpoint, or recover your live store; in WAL mode the read
+doesn't block OpenCode's writes, and a short busy-timeout rides out the rare
+exclusive moment. Reading directly (rather than copying the whole DB first) keeps
+memory proportional to the recent rows actually parsed, not the full history.
+Storage location is documented at
 [opencode.ai/docs/troubleshooting](https://opencode.ai/docs/troubleshooting/);
 the schema lives in the OSS repo (`sst/opencode`). Auto-detected: the OpenCode
 tab appears only when a matching DB exists.
@@ -31,6 +32,10 @@ tab appears only when a matching DB exists.
   ```
   tokens = input + output + cache_read + cache_creation(=cache.write)
   ```
+
+  OpenCode stores only the *visible* output in `output` and counts `reasoning`
+  separately, so reasoning is folded into the output total (and priced at the
+  output rate) to match the inclusive convention the other providers use.
 
 - **Model** from `data.modelID` (e.g. `qwen3:8b`, `claude-...`).
 - **Project** from `data.path.cwd` (the working directory), labeled like the other

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -3,9 +3,10 @@
 ## Where the data comes from
 
 `~/.local/share/opencode/opencode.db` — a local SQLite store (overridable with
-`OPENCODE_HOME`, or `$XDG_DATA_HOME/opencode`). Read-only and **immutable**, so
-agent-walker never locks the DB, never recovers its WAL, and never writes to your
-OpenCode store. Storage location is documented at
+`OPENCODE_HOME`, or `$XDG_DATA_HOME/opencode`). agent-walker reads a **private
+snapshot copy** (the DB plus its WAL, copied to a temp dir) and never lets SQLite
+open your live store, so it can't lock, checkpoint, or corrupt it. Storage
+location is documented at
 [opencode.ai/docs/troubleshooting](https://opencode.ai/docs/troubleshooting/);
 the schema lives in the OSS repo (`sst/opencode`). Auto-detected: the OpenCode
 tab appears only when `opencode.db` exists.
@@ -43,5 +44,5 @@ the pricing database, so their cost shows as $0 even though their tokens count.
 
 - Only `opencode.db` is read; per-channel stores (`opencode-<channel>.db`) are
   not, for now.
-- Immutable reads see the last-committed state, so a session still being written
-  may lag by one checkpoint.
+- The snapshot is taken at launch, so a session still being written shows up on
+  the next run.

--- a/docs/opencode.md
+++ b/docs/opencode.md
@@ -2,14 +2,25 @@
 
 ## Where the data comes from
 
-`~/.local/share/opencode/opencode.db` — a local SQLite store (overridable with
-`OPENCODE_HOME`, or `$XDG_DATA_HOME/opencode`). agent-walker reads a **private
-snapshot copy** (the DB plus its WAL, copied to a temp dir) and never lets SQLite
-open your live store, so it can't lock, checkpoint, or corrupt it. Storage
-location is documented at
+`~/.local/share/opencode/opencode.db` — a local SQLite store (the data dir is
+overridable with `OPENCODE_HOME`, or `$XDG_DATA_HOME/opencode`). agent-walker
+follows OpenCode's own database resolver:
+
+- if `OPENCODE_DB` is set, that file is read (an absolute path as-is, a relative
+  one under the data dir; `:memory:` can't be read from another process, so it's
+  skipped);
+- otherwise every `opencode*.db` in the data dir is read, covering both the
+  default `opencode.db` and the `opencode-<channel>.db` a non-stable install
+  (e.g. a `dev` build) writes.
+
+It opens each DB **read-only** and takes a consistent snapshot through SQLite's
+online **Backup API** (an in-memory copy under SQLite's read lock), then reads
+from that copy — so it never locks, checkpoints, writes, or corrupts your live
+store, and there's no file-copy race between the DB and its WAL. Storage location
+is documented at
 [opencode.ai/docs/troubleshooting](https://opencode.ai/docs/troubleshooting/);
 the schema lives in the OSS repo (`sst/opencode`). Auto-detected: the OpenCode
-tab appears only when `opencode.db` exists.
+tab appears only when a matching DB exists.
 
 ## What's captured
 
@@ -42,7 +53,7 @@ the pricing database, so their cost shows as $0 even though their tokens count.
 
 ## Caveats
 
-- Only `opencode.db` is read; per-channel stores (`opencode-<channel>.db`) are
-  not, for now.
 - The snapshot is taken at launch, so a session still being written shows up on
   the next run.
+- A live DB whose WAL still needs recovery and has no `-shm` present can't be
+  opened read-only; that DB is skipped rather than touched.

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use clap_complete::Shell;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::analyzer::summarize;
-use crate::collector::{agy, claude, codex};
+use crate::collector::{agy, claude, codex, opencode};
 use crate::format::snapshot_app;
 use crate::model::{AppSummary, Collection};
 use crate::ui;
@@ -37,6 +37,13 @@ pub struct Args {
     /// never feeds the token totals.
     #[arg(long, value_name = "DIR")]
     pub agy_dir: Option<PathBuf>,
+
+    /// Override the OpenCode data directory (default `~/.local/share/opencode`,
+    /// or `$OPENCODE_HOME` / `$XDG_DATA_HOME/opencode`). Auto-detected: its tab
+    /// appears only when `opencode.db` is present. Tokens are read from the
+    /// local SQLite store.
+    #[arg(long, value_name = "DIR")]
+    pub opencode_dir: Option<PathBuf>,
 
     /// Analysis window. Defaults to 30 days — Claude Code retains roughly a
     /// month of logs. The codename level is always computed from the most recent
@@ -84,6 +91,10 @@ pub struct Config {
     /// rather than fatal, since Antigravity is optional — its tab only shows up
     /// when logs are actually found there.
     pub agy_dir: Option<PathBuf>,
+    /// OpenCode data directory, or `None` when it can't be resolved. Optional and
+    /// auto-detected like Antigravity: the tab appears only when `opencode.db`
+    /// exists there.
+    pub opencode_dir: Option<PathBuf>,
     pub days: u16,
     pub use_cache: bool,
     /// Local UTC offset captured at startup (single-threaded moment), used to
@@ -119,6 +130,8 @@ pub fn run(args: Args) -> Result<()> {
         // swallowed to None instead of fatal — agy is optional, so a sandbox
         // without a home dir should still start and just omit the agy tab.
         agy_dir: args.agy_dir.or_else(|| default_agy_dir().ok()),
+        // Same treatment as agy: auto-detected, resolution failure swallowed.
+        opencode_dir: args.opencode_dir.or_else(|| default_opencode_dir().ok()),
         days: args.days,
         use_cache: !args.no_cache,
         local_offset,
@@ -214,33 +227,44 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
         .max(u64::try_from(crate::codename::CODENAME_WINDOW_DAYS).unwrap_or(30) + 1);
     let mtime_floor = SystemTime::now().checked_sub(StdDuration::from_secs(history_days * 86_400));
 
-    let (codex_result, (agy_result, claude_collection)) = std::thread::scope(|scope| {
-        let codex_handle = scope.spawn(|| {
-            codex::collect(
-                &config.codex_dir,
+    let (codex_result, agy_result, opencode_result, claude_collection) =
+        std::thread::scope(|scope| {
+            let codex_handle = scope.spawn(|| {
+                codex::collect(
+                    &config.codex_dir,
+                    mtime_floor,
+                    config.use_cache,
+                    config.local_offset,
+                )
+            });
+            // Antigravity and OpenCode are probed whenever their directory
+            // resolved; the collector returns an empty collection for a missing
+            // dir / DB, and an empty provider is filtered out before it ever
+            // becomes a tab. (Antigravity logs carry no token usage; OpenCode's
+            // SQLite store does.)
+            let agy_handle = scope.spawn(|| {
+                config.agy_dir.as_ref().map(|dir| {
+                    agy::collect(dir, mtime_floor, config.use_cache, config.local_offset)
+                })
+            });
+            let opencode_handle = scope.spawn(|| {
+                config.opencode_dir.as_ref().map(|dir| {
+                    opencode::collect(dir, mtime_floor, config.use_cache, config.local_offset)
+                })
+            });
+            let claude_collection = claude::collect(
+                &config.claude_dir,
                 mtime_floor,
                 config.use_cache,
                 config.local_offset,
+            );
+            (
+                codex_handle.join(),
+                agy_handle.join(),
+                opencode_handle.join(),
+                claude_collection,
             )
         });
-        // Antigravity is probed whenever its directory resolved; the collector
-        // returns an empty collection for a missing dir, and an empty provider
-        // is filtered out before it ever becomes a tab. Its logs carry no token
-        // usage, so it never skews the totals regardless.
-        let agy_handle = scope.spawn(|| {
-            config
-                .agy_dir
-                .as_ref()
-                .map(|dir| agy::collect(dir, mtime_floor, config.use_cache, config.local_offset))
-        });
-        let claude_collection = claude::collect(
-            &config.claude_dir,
-            mtime_floor,
-            config.use_cache,
-            config.local_offset,
-        );
-        (codex_handle.join(), (agy_handle.join(), claude_collection))
-    });
 
     let mut collections = vec![
         claude_collection,
@@ -248,6 +272,9 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
     ];
     if let Some(agy) = agy_result.map_err(|_| anyhow!("Antigravity collector thread panicked"))? {
         collections.push(agy);
+    }
+    if let Some(oc) = opencode_result.map_err(|_| anyhow!("OpenCode collector thread panicked"))? {
+        collections.push(oc);
     }
 
     let providers = collections
@@ -280,6 +307,10 @@ fn default_codex_dir() -> Result<PathBuf> {
 
 fn default_agy_dir() -> Result<PathBuf> {
     crate::paths::agy_home()
+}
+
+fn default_opencode_dir() -> Result<PathBuf> {
+    crate::paths::opencode_home()
 }
 
 fn demo_enabled() -> bool {

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,6 +1,7 @@
 pub mod agy;
 pub mod claude;
 pub mod codex;
+pub mod opencode;
 
 use std::collections::{HashMap, HashSet};
 use std::fs;

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -110,8 +110,14 @@ fn parse_messages(
         return;
     };
 
-    for (session_id, data) in rows.flatten() {
+    for row in rows {
         collection.stats.lines_seen += 1;
+        let Ok((session_id, data)) = row else {
+            // A row-level SQLite error (type mismatch, mid-scan corruption)
+            // should surface in the stats, not vanish like `flatten()` would.
+            collection.stats.parse_errors += 1;
+            continue;
+        };
         let Ok(value) = serde_json::from_str::<Value>(&data) else {
             collection.stats.parse_errors += 1;
             continue;
@@ -194,8 +200,12 @@ fn parse_tool_parts(
         return;
     };
 
-    for (session_id, data) in rows.flatten() {
+    for row in rows {
         collection.stats.lines_seen += 1;
+        let Ok((session_id, data)) = row else {
+            collection.stats.parse_errors += 1;
+            continue;
+        };
         let Ok(value) = serde_json::from_str::<Value>(&data) else {
             collection.stats.parse_errors += 1;
             continue;

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -8,18 +8,21 @@
 //! (`type:"tool"`, `tool`). Storage layout is documented at
 //! <https://opencode.ai/docs/troubleshooting/> and the OSS repo (sst/opencode).
 //!
-//! We read a **private snapshot copy** of the DB (copied to a temp dir, WAL and
-//! all) and never let SQLite open the user's live store, so we can't lock,
-//! checkpoint, or corrupt it. Cost is left to the shared LiteLLM pricing path
-//! like every other provider — the per-message `cost` OpenCode records (and
-//! local models such as Ollama, which report no priced usage) is not used here.
+//! We open the live DB **read-only** and take a consistent in-memory snapshot
+//! through SQLite's online Backup API, then read from that copy. The source is
+//! never written, locked for writes, or checkpointed, and the backup runs under
+//! SQLite's own read lock — so there's no `fs::copy` race between the db and its
+//! `-wal`. Cost is left to the shared LiteLLM pricing path like every other
+//! provider — the per-message `cost` OpenCode records (and local models such as
+//! Ollama, which report no priced usage) is not used here.
 
+use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, params};
+use rusqlite::backup::Backup;
+use rusqlite::{Connection, OpenFlags, params};
 use serde_json::Value;
-use tempfile::TempDir;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::collector::project_from_cwd;
@@ -35,16 +38,6 @@ pub fn collect(
     local_offset: UtcOffset,
 ) -> Collection {
     let mut collection = Collection::new(Provider::OpenCode, root.to_path_buf());
-    let db_path = root.join("opencode.db");
-    if !db_path.exists() {
-        return collection;
-    }
-    // `_snapshot` must outlive `conn` — it owns the temp copy `conn` reads.
-    let Some((conn, _snapshot)) = open_snapshot(&db_path) else {
-        collection.stats.unreadable_files += 1;
-        return collection;
-    };
-    collection.stats.files_seen += 1;
 
     // Events older than the history window can't be relevant; the timestamps are
     // epoch milliseconds (`time.created`), so compare in the same unit.
@@ -53,8 +46,15 @@ pub fn collect(
         .and_then(|elapsed| i64::try_from(elapsed.as_millis()).ok())
         .unwrap_or(0);
 
-    parse_messages(&conn, floor_ms, local_offset, &mut collection);
-    parse_tool_parts(&conn, floor_ms, local_offset, &mut collection);
+    for db_path in db_paths(root) {
+        let Some(conn) = open_snapshot(&db_path) else {
+            collection.stats.unreadable_files += 1;
+            continue;
+        };
+        collection.stats.files_seen += 1;
+        parse_messages(&conn, floor_ms, local_offset, &mut collection);
+        parse_tool_parts(&conn, floor_ms, local_offset, &mut collection);
+    }
 
     collection.stats.usage_events = collection.usage_events.len();
     collection.stats.tool_events = collection.tool_events.len();
@@ -62,31 +62,76 @@ pub fn collect(
     collection
 }
 
-/// Copy the DB (plus any `-wal` / `-shm` sidecars) into a throwaway temp dir and
-/// open the *copy*. The user's store is only ever read via `fs::copy` — never
-/// opened by SQLite — so a live OpenCode session can't be locked, checkpointed,
-/// or corrupted, and copying the WAL keeps the snapshot consistent (no
-/// `immutable=1` foot-gun). The `TempDir` is returned so it outlives the
-/// connection and is removed on drop.
-fn open_snapshot(db: &Path) -> Option<(Connection, TempDir)> {
-    let snapshot = TempDir::new().ok()?;
-    let dest = snapshot.path().join("opencode.db");
-    std::fs::copy(db, &dest).ok()?;
-    for suffix in ["-wal", "-shm"] {
-        let sidecar = with_suffix(db, suffix);
-        if sidecar.exists() {
-            let _ = std::fs::copy(&sidecar, with_suffix(&dest, suffix));
-        }
-    }
-    Connection::open(&dest).ok().map(|conn| (conn, snapshot))
+/// The OpenCode DB file(s) to read. Reads the `OPENCODE_DB` override from the
+/// environment, then defers to [`resolve_db_paths`] (kept env-free so it stays
+/// testable, like `paths::resolve_root`).
+fn db_paths(root: &Path) -> Vec<PathBuf> {
+    resolve_db_paths(root, std::env::var_os("OPENCODE_DB"))
 }
 
-/// SQLite sidecar path: the DB filename with a suffix appended (`opencode.db`
-/// → `opencode.db-wal`). Appends to the whole path so non-UTF-8 names survive.
-fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
-    let mut name = path.as_os_str().to_owned();
-    name.push(suffix);
-    PathBuf::from(name)
+/// Mirror OpenCode's own resolver: `OPENCODE_DB` wins (an absolute path used
+/// as-is, a relative one joined under the data dir; `:memory:` can't be read
+/// from another process, so it's skipped). Otherwise read every `opencode*.db`
+/// in the data dir, which covers both the default `opencode.db` and the
+/// per-channel `opencode-<channel>.db` a non-stable install writes.
+fn resolve_db_paths(root: &Path, override_db: Option<OsString>) -> Vec<PathBuf> {
+    if let Some(db) = override_db {
+        if db == *OsStr::new(":memory:") {
+            return Vec::new();
+        }
+        let path = PathBuf::from(&db);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        };
+        // A missing override is "absent", not "unreadable" — skip it silently.
+        return if path.exists() {
+            vec![path]
+        } else {
+            Vec::new()
+        };
+    }
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            let is_db = path
+                .extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("db"));
+            let named_opencode = path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("opencode"));
+            is_db && named_opencode
+        })
+        .collect();
+    // Deterministic order so files_seen / parse order doesn't depend on the FS.
+    paths.sort();
+    paths
+}
+
+/// Open the live DB read-only and copy it into an in-memory database via
+/// SQLite's online Backup API, returning a connection to that copy. The backup
+/// holds a read lock for the duration of the page copy, so it's a consistent
+/// snapshot even mid-write — no `fs::copy` race between the db and its `-wal`,
+/// no temp files, and the user's store is never written or checkpointed (the
+/// `immutable=1` foot-gun is avoided too). A live DB whose WAL needs recovery
+/// with no `-shm` present can't be opened read-only; that degrades to an empty
+/// collection rather than touching the store.
+fn open_snapshot(db: &Path) -> Option<Connection> {
+    let source = Connection::open_with_flags(db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    let mut snapshot = Connection::open_in_memory().ok()?;
+    {
+        let backup = Backup::new(&source, &mut snapshot).ok()?;
+        backup
+            .run_to_completion(1024, Duration::from_millis(0), None)
+            .ok()?;
+    }
+    Some(snapshot)
 }
 
 /// One usage + duration event per assistant message (the per-turn totals live on
@@ -246,7 +291,11 @@ mod tests {
     const ASSISTANT_DONE_MS: i64 = 1_781_542_436_778;
 
     fn write_db(dir: &Path) {
-        let conn = Connection::open(dir.join("opencode.db")).expect("open temp db");
+        write_db_at(&dir.join("opencode.db"));
+    }
+
+    fn write_db_at(db: &Path) {
+        let conn = Connection::open(db).expect("open temp db");
         conn.execute_batch(
             "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
              CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);",
@@ -301,6 +350,60 @@ mod tests {
 
         // A touch per message (user + assistant), for concurrency / active days.
         assert_eq!(collection.session_touches.len(), 2);
+    }
+
+    #[test]
+    fn channel_db_is_collected() {
+        // A non-stable install writes `opencode-<channel>.db` instead of the
+        // default name; the glob must still pick it up.
+        let dir = TempDir::new().expect("tempdir");
+        write_db_at(&dir.path().join("opencode-dev.db"));
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.stats.files_seen, 1);
+    }
+
+    #[test]
+    fn resolve_db_paths_globs_channel_dbs_sorted() {
+        let dir = TempDir::new().expect("tempdir");
+        write_db_at(&dir.path().join("opencode.db"));
+        write_db_at(&dir.path().join("opencode-beta.db"));
+        // A `-wal` sidecar must not be mistaken for a DB file.
+        std::fs::write(dir.path().join("opencode.db-wal"), b"").expect("wal");
+        let paths = resolve_db_paths(dir.path(), None);
+        assert_eq!(
+            paths,
+            vec![
+                dir.path().join("opencode-beta.db"),
+                dir.path().join("opencode.db"),
+            ]
+        );
+    }
+
+    #[test]
+    fn resolve_db_paths_honors_absolute_override() {
+        let dir = TempDir::new().expect("tempdir");
+        let custom = dir.path().join("custom.db");
+        write_db_at(&custom);
+        // Even with a default db present, the absolute override wins exclusively.
+        write_db_at(&dir.path().join("opencode.db"));
+        let paths = resolve_db_paths(dir.path(), Some(custom.clone().into_os_string()));
+        assert_eq!(paths, vec![custom]);
+    }
+
+    #[test]
+    fn resolve_db_paths_memory_override_is_skipped() {
+        let dir = TempDir::new().expect("tempdir");
+        write_db_at(&dir.path().join("opencode.db"));
+        let paths = resolve_db_paths(dir.path(), Some(OsString::from(":memory:")));
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn resolve_db_paths_missing_override_is_absent() {
+        let dir = TempDir::new().expect("tempdir");
+        let paths = resolve_db_paths(dir.path(), Some(OsString::from("/no/such/file.db")));
+        assert!(paths.is_empty());
     }
 
     #[test]

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -8,19 +8,21 @@
 //! (`type:"tool"`, `tool`). Storage layout is documented at
 //! <https://opencode.ai/docs/troubleshooting/> and the OSS repo (sst/opencode).
 //!
-//! We open the live DB **read-only** and take a consistent in-memory snapshot
-//! through SQLite's online Backup API, then read from that copy. The source is
-//! never written, locked for writes, or checkpointed, and the backup runs under
-//! SQLite's own read lock — so there's no `fs::copy` race between the db and its
-//! `-wal`. Cost is left to the shared LiteLLM pricing path like every other
-//! provider — the per-message `cost` OpenCode records (and local models such as
-//! Ollama, which report no priced usage) is not used here.
+//! We open the live DB **read-only** and read it directly. The read-only flag
+//! means SQLite can never write the user's store (no checkpoint, no recovery
+//! write); in WAL mode our reads don't block OpenCode's writes, and a brief
+//! `busy_timeout` rides out the rare exclusive moments. Reading directly — rather
+//! than copying the whole DB into memory first — keeps memory proportional to
+//! the recent-window rows we actually parse, not the entire history. Cost is
+//! left to the shared LiteLLM pricing path like every other provider — the
+//! per-message `cost` OpenCode records (and local models such as Ollama, which
+//! report no priced usage) is not used here.
 
+use std::collections::HashSet;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use rusqlite::backup::Backup;
 use rusqlite::{Connection, OpenFlags, params};
 use serde_json::Value;
 use time::{OffsetDateTime, UtcOffset};
@@ -46,14 +48,31 @@ pub fn collect(
         .and_then(|elapsed| i64::try_from(elapsed.as_millis()).ok())
         .unwrap_or(0);
 
+    // Across multiple DB files (e.g. a default store plus a channel store, or a
+    // copy left over from a migration) the same row can appear twice; dedupe by
+    // its primary-key id so a turn isn't counted once per file.
+    let mut seen_messages = HashSet::new();
+    let mut seen_parts = HashSet::new();
     for db_path in db_paths(root) {
-        let Some(conn) = open_snapshot(&db_path) else {
+        let Some(conn) = open_readonly(&db_path) else {
             collection.stats.unreadable_files += 1;
             continue;
         };
         collection.stats.files_seen += 1;
-        parse_messages(&conn, floor_ms, local_offset, &mut collection);
-        parse_tool_parts(&conn, floor_ms, local_offset, &mut collection);
+        parse_messages(
+            &conn,
+            floor_ms,
+            local_offset,
+            &mut collection,
+            &mut seen_messages,
+        );
+        parse_tool_parts(
+            &conn,
+            floor_ms,
+            local_offset,
+            &mut collection,
+            &mut seen_parts,
+        );
     }
 
     collection.stats.usage_events = collection.usage_events.len();
@@ -107,7 +126,8 @@ fn resolve_db_paths(root: &Path, override_db: Option<OsString>) -> Vec<PathBuf> 
                 .file_name()
                 .and_then(|name| name.to_str())
                 .is_some_and(|name| name.starts_with("opencode"));
-            is_db && named_opencode
+            // A directory matching the pattern isn't a DB — don't try to open it.
+            is_db && named_opencode && path.is_file()
         })
         .collect();
     // Deterministic order so files_seen / parse order doesn't depend on the FS.
@@ -115,29 +135,15 @@ fn resolve_db_paths(root: &Path, override_db: Option<OsString>) -> Vec<PathBuf> 
     paths
 }
 
-/// Open the live DB read-only and copy it into an in-memory database via
-/// SQLite's online Backup API, returning a connection to that copy. The backup
-/// holds a read lock for the duration of the page copy, so it's a consistent
-/// snapshot even mid-write — no `fs::copy` race between the db and its `-wal`,
-/// no temp files, and the user's store is never written or checkpointed (the
-/// `immutable=1` foot-gun is avoided too). A live DB whose WAL needs recovery
-/// with no `-shm` present can't be opened read-only; that degrades to an empty
-/// collection rather than touching the store.
-fn open_snapshot(db: &Path) -> Option<Connection> {
-    let source = Connection::open_with_flags(db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
-    // If OpenCode holds a write lock as we attach, wait briefly rather than
-    // failing the snapshot outright.
-    let _ = source.busy_timeout(Duration::from_millis(500));
-    let mut snapshot = Connection::open_in_memory().ok()?;
-    {
-        let backup = Backup::new(&source, &mut snapshot).ok()?;
-        // Pause between any step that hits BUSY/LOCKED so a contended copy backs
-        // off instead of spinning.
-        backup
-            .run_to_completion(1024, Duration::from_millis(25), None)
-            .ok()?;
-    }
-    Some(snapshot)
+/// Open the live DB read-only. The read-only flag guarantees SQLite never writes
+/// the user's store; the `busy_timeout` rides out a brief write lock (e.g. a
+/// checkpoint restart) instead of failing immediately. A WAL DB that needs
+/// recovery with no `-shm` present can't be opened read-only; that DB is skipped
+/// rather than touched.
+fn open_readonly(db: &Path) -> Option<Connection> {
+    let conn = Connection::open_with_flags(db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    let _ = conn.busy_timeout(Duration::from_millis(500));
+    Some(conn)
 }
 
 /// One usage + duration event per assistant message (the per-turn totals live on
@@ -147,11 +153,12 @@ fn parse_messages(
     floor_ms: i64,
     local_offset: UtcOffset,
     collection: &mut Collection,
+    seen: &mut HashSet<String>,
 ) {
     // Filter on the indexed `time_created` column so SQLite skips out-of-window
     // rows before we ever parse their JSON in Rust.
     let Ok(mut stmt) =
-        conn.prepare("SELECT session_id, data FROM message WHERE time_created >= ?1")
+        conn.prepare("SELECT id, session_id, data FROM message WHERE time_created >= ?1")
     else {
         return;
     };
@@ -160,8 +167,9 @@ fn parse_messages(
         // could still carry a NULL — default it rather than dropping the row
         // (and its tokens) as a type-mismatch parse error.
         Ok((
-            row.get::<_, Option<String>>(0)?.unwrap_or_default(),
-            row.get::<_, String>(1)?,
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            row.get::<_, String>(2)?,
         ))
     }) else {
         return;
@@ -169,12 +177,16 @@ fn parse_messages(
 
     for row in rows {
         collection.stats.lines_seen += 1;
-        let Ok((session_id, data)) = row else {
+        let Ok((id, session_id, data)) = row else {
             // A row-level SQLite error (type mismatch, mid-scan corruption)
             // should surface in the stats, not vanish like `flatten()` would.
             collection.stats.parse_errors += 1;
             continue;
         };
+        // Already counted from another DB file (a copied store) — skip the dup.
+        if !seen.insert(id) {
+            continue;
+        }
         let Ok(value) = serde_json::from_str::<Value>(&data) else {
             collection.stats.parse_errors += 1;
             continue;
@@ -197,7 +209,11 @@ fn parse_messages(
 
         let usage = TokenUsage {
             input_tokens: token(&value, "/tokens/input"),
-            output_tokens: token(&value, "/tokens/output"),
+            // OpenCode stores only the *visible* output here and counts
+            // reasoning separately; fold reasoning in so token totals and cost
+            // match the inclusive convention the other providers use.
+            output_tokens: token(&value, "/tokens/output")
+                .saturating_add(token(&value, "/tokens/reasoning")),
             reasoning_output_tokens: token(&value, "/tokens/reasoning"),
             cache_creation_input_tokens: token(&value, "/tokens/cache/write"),
             cache_read_input_tokens: token(&value, "/tokens/cache/read"),
@@ -243,21 +259,26 @@ fn parse_tool_parts(
     floor_ms: i64,
     local_offset: UtcOffset,
     collection: &mut Collection,
+    seen: &mut HashSet<String>,
 ) {
-    // `time_created >= ?1` first lets SQLite drop out-of-window rows on the cheap
-    // integer column before the per-row `json_extract` ever runs.
-    let Ok(mut stmt) = conn.prepare(
-        "SELECT session_id, data FROM part WHERE time_created >= ?1 AND json_extract(data, '$.type') = 'tool'",
-    ) else {
+    // Filter only on the indexed `time_created` integer column in SQL, and do the
+    // `type == "tool"` check in Rust. Putting `json_extract` in the WHERE clause
+    // makes a single malformed `data` row raise "malformed JSON" and abort the
+    // whole result set, losing every later tool call in this DB.
+    let Ok(mut stmt) = conn
+        .prepare("SELECT id, session_id, time_created, data FROM part WHERE time_created >= ?1")
+    else {
         return;
     };
     let Ok(rows) = stmt.query_map(params![floor_ms], |row| {
         // `session_id` is NOT NULL in OpenCode's own schema, but a corrupt DB
-        // could still carry a NULL — default it rather than dropping the row
-        // (and its tokens) as a type-mismatch parse error.
+        // could still carry a NULL — default it rather than dropping the row as
+        // a type-mismatch parse error.
         Ok((
-            row.get::<_, Option<String>>(0)?.unwrap_or_default(),
-            row.get::<_, String>(1)?,
+            row.get::<_, String>(0)?,
+            row.get::<_, Option<String>>(1)?.unwrap_or_default(),
+            row.get::<_, i64>(2)?,
+            row.get::<_, String>(3)?,
         ))
     }) else {
         return;
@@ -265,7 +286,7 @@ fn parse_tool_parts(
 
     for row in rows {
         collection.stats.lines_seen += 1;
-        let Ok((session_id, data)) = row else {
+        let Ok((id, session_id, time_created, data)) = row else {
             collection.stats.parse_errors += 1;
             continue;
         };
@@ -273,12 +294,25 @@ fn parse_tool_parts(
             collection.stats.parse_errors += 1;
             continue;
         };
+        if value.get("type").and_then(Value::as_str) != Some("tool") {
+            continue;
+        }
         let Some(tool_name) = value.get("tool").and_then(Value::as_str) else {
             continue;
         };
-        let start_ms = value.pointer("/state/time/start").and_then(Value::as_i64);
+        // Already counted from another DB file (a copied store) — skip the dup.
+        if !seen.insert(id) {
+            continue;
+        }
+        // Prefer the tool's own start time; fall back to the row's `time_created`
+        // so a tool without a recorded start isn't dropped by the analyzer for
+        // lacking a timestamp.
+        let start_ms = value
+            .pointer("/state/time/start")
+            .and_then(Value::as_i64)
+            .unwrap_or(time_created);
         collection.tool_events.push(ToolEvent {
-            timestamp: start_ms.and_then(|ms| ms_to_offset(ms, local_offset)),
+            timestamp: ms_to_offset(start_ms, local_offset),
             session_id: Some(session_id),
             tool_name: tool_name.to_owned(),
             subagent_type: None,
@@ -349,13 +383,15 @@ mod tests {
         assert_eq!(collection.usage_events.len(), 1);
         let event = &collection.usage_events[0];
         assert_eq!(event.usage.input_tokens, 100);
-        assert_eq!(event.usage.output_tokens, 20);
+        // OpenCode's stored output (20) excludes reasoning (5); we fold reasoning
+        // in, so output_tokens is the inclusive 25 and reasoning is also kept.
+        assert_eq!(event.usage.output_tokens, 25);
         assert_eq!(event.usage.reasoning_output_tokens, 5);
         assert_eq!(event.usage.cache_read_input_tokens, 40);
         assert_eq!(event.usage.cache_creation_input_tokens, 10);
-        // token_volume = input + output + cache_create + cache_read (reasoning is
-        // a subset of output, not added on top).
-        assert_eq!(event.usage.token_volume(), 170);
+        // token_volume = input + output(incl. reasoning) + cache_create +
+        // cache_read = 100 + 25 + 10 + 40.
+        assert_eq!(event.usage.token_volume(), 175);
         assert_eq!(event.model.as_deref(), Some("qwen3:8b"));
         assert_eq!(event.project.as_deref(), Some("somewhere/proj"));
 
@@ -443,6 +479,76 @@ mod tests {
         assert!(collection.usage_events.is_empty());
         assert!(collection.tool_events.is_empty());
         assert!(collection.session_touches.is_empty());
+    }
+
+    #[test]
+    fn duplicate_rows_across_db_files_are_counted_once() {
+        // A copied store left beside the default (same row ids) must not double
+        // count the same turn.
+        let dir = TempDir::new().expect("tempdir");
+        write_db_at(&dir.path().join("opencode.db"));
+        write_db_at(&dir.path().join("opencode-prod.db"));
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert_eq!(collection.stats.files_seen, 2);
+        // One assistant message and one tool part, despite two identical DBs.
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.tool_events.len(), 1);
+        assert_eq!(collection.session_touches.len(), 2);
+    }
+
+    #[test]
+    fn malformed_part_json_does_not_drop_later_tools() {
+        // A single malformed part row must not abort the whole result set; later
+        // valid tool calls in the same DB still come through.
+        let dir = TempDir::new().expect("tempdir");
+        let conn = Connection::open(dir.path().join("opencode.db")).expect("open temp db");
+        conn.execute_batch(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);",
+        )
+        .expect("create schema");
+        conn.execute(
+            "INSERT INTO part VALUES ('p0','m1','s1',1781542400000,1781542400000,'{not valid json')",
+            [],
+        )
+        .expect("insert bad");
+        let good = r#"{"type":"tool","tool":"bash","state":{"time":{"start":1781542400500}}}"#;
+        conn.execute(
+            "INSERT INTO part VALUES ('p1','m1','s1',1781542400600,1781542400600,?1)",
+            [good],
+        )
+        .expect("insert good");
+        drop(conn);
+
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert_eq!(collection.tool_events.len(), 1);
+        assert_eq!(collection.tool_events[0].tool_name, "bash");
+        assert_eq!(collection.stats.parse_errors, 1);
+    }
+
+    #[test]
+    fn tool_without_start_time_falls_back_to_time_created() {
+        let dir = TempDir::new().expect("tempdir");
+        let conn = Connection::open(dir.path().join("opencode.db")).expect("open temp db");
+        conn.execute_batch(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);",
+        )
+        .expect("create schema");
+        // A tool part with no state.time.start.
+        let tool = r#"{"type":"tool","tool":"read"}"#;
+        conn.execute(
+            "INSERT INTO part VALUES ('p1','m1','s1',1781542400000,1781542400000,?1)",
+            [tool],
+        )
+        .expect("insert");
+        drop(conn);
+
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert_eq!(collection.tool_events.len(), 1);
+        // The event keeps a timestamp (from time_created) so the analyzer doesn't
+        // drop it.
+        assert!(collection.tool_events[0].timestamp.is_some());
     }
 
     #[test]

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -1,0 +1,296 @@
+//! OpenCode collector — reads OpenCode's local SQLite store.
+//!
+//! Unlike the JSONL collectors (Claude / Codex / Antigravity), OpenCode keeps
+//! everything in `<root>/opencode.db` (SQLite). Per-assistant-message token
+//! usage lives in the `message` table's `data` JSON
+//! (`tokens.{input,output,reasoning,cache.{read,write}}`, `modelID`,
+//! `path.cwd`, `time.{created,completed}`); tool calls live in `part`
+//! (`type:"tool"`, `tool`). Storage layout is documented at
+//! <https://opencode.ai/docs/troubleshooting/> and the OSS repo (sst/opencode).
+//!
+//! We open the DB **read-only and immutable** (no locks, no WAL recovery) so
+//! agent-walker never touches the user's OpenCode store. Cost is left to the
+//! shared LiteLLM pricing path like every other provider — the per-message
+//! `cost` OpenCode records (and local models such as Ollama, which report no
+//! priced usage) is not used here.
+
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, OpenFlags};
+use serde_json::Value;
+use time::{OffsetDateTime, UtcOffset};
+
+use crate::collector::project_from_cwd;
+use crate::model::{
+    Collection, DurationEvent, Provider, SessionTouch, SourceKind, TokenUsage, ToolEvent,
+    UsageEvent,
+};
+
+pub fn collect(
+    root: &Path,
+    mtime_floor: Option<SystemTime>,
+    _use_cache: bool,
+    local_offset: UtcOffset,
+) -> Collection {
+    let mut collection = Collection::new(Provider::OpenCode, root.to_path_buf());
+    let db_path = root.join("opencode.db");
+    if !db_path.exists() {
+        return collection;
+    }
+    let Some(conn) = open_readonly(&db_path) else {
+        collection.stats.unreadable_files += 1;
+        return collection;
+    };
+    collection.stats.files_seen += 1;
+
+    // Events older than the history window can't be relevant; the timestamps are
+    // epoch milliseconds (`time.created`), so compare in the same unit.
+    let floor_ms = mtime_floor
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .and_then(|elapsed| i64::try_from(elapsed.as_millis()).ok())
+        .unwrap_or(0);
+
+    parse_messages(&conn, floor_ms, local_offset, &mut collection);
+    parse_tool_parts(&conn, floor_ms, local_offset, &mut collection);
+
+    collection.stats.usage_events = collection.usage_events.len();
+    collection.stats.tool_events = collection.tool_events.len();
+    collection.stats.duration_events = collection.duration_events.len();
+    collection
+}
+
+/// Open the DB read-only and immutable: SQLite takes no locks and never tries to
+/// recover the WAL, so a live OpenCode session can't be disturbed and we can't
+/// write to the user's store. Immutable reads the last-committed state.
+fn open_readonly(db: &Path) -> Option<Connection> {
+    let uri = format!("file:{}?immutable=1", db.to_string_lossy());
+    Connection::open_with_flags(
+        uri,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .ok()
+}
+
+/// One usage + duration event per assistant message (the per-turn totals live on
+/// the message), plus a session touch per message for concurrency / active days.
+fn parse_messages(
+    conn: &Connection,
+    floor_ms: i64,
+    local_offset: UtcOffset,
+    collection: &mut Collection,
+) {
+    let Ok(mut stmt) = conn.prepare("SELECT session_id, data FROM message") else {
+        return;
+    };
+    let Ok(rows) = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    }) else {
+        return;
+    };
+
+    for (session_id, data) in rows.flatten() {
+        collection.stats.lines_seen += 1;
+        let Ok(value) = serde_json::from_str::<Value>(&data) else {
+            collection.stats.parse_errors += 1;
+            continue;
+        };
+        let Some(created_ms) = value.pointer("/time/created").and_then(Value::as_i64) else {
+            continue;
+        };
+        if created_ms < floor_ms {
+            continue;
+        }
+        let Some(timestamp) = ms_to_offset(created_ms, local_offset) else {
+            continue;
+        };
+
+        collection.session_touches.push(SessionTouch {
+            timestamp,
+            session_id: session_id.clone(),
+        });
+
+        if value.get("role").and_then(Value::as_str) != Some("assistant") {
+            continue;
+        }
+
+        let usage = TokenUsage {
+            input_tokens: token(&value, "/tokens/input"),
+            output_tokens: token(&value, "/tokens/output"),
+            reasoning_output_tokens: token(&value, "/tokens/reasoning"),
+            cache_creation_input_tokens: token(&value, "/tokens/cache/write"),
+            cache_read_input_tokens: token(&value, "/tokens/cache/read"),
+            ..TokenUsage::default()
+        };
+        collection.usage_events.push(UsageEvent {
+            timestamp: Some(timestamp),
+            session_id: Some(session_id.clone()),
+            model: value
+                .get("modelID")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            source_kind: SourceKind::Main,
+            attribution_agent: None,
+            project: value
+                .pointer("/path/cwd")
+                .and_then(Value::as_str)
+                .map(project_from_cwd),
+            usage,
+        });
+
+        if let Some(completed_ms) = value.pointer("/time/completed").and_then(Value::as_i64) {
+            collection.duration_events.push(DurationEvent {
+                timestamp: Some(timestamp),
+                session_id: Some(session_id),
+                duration_ms: u64::try_from(completed_ms - created_ms).unwrap_or(0),
+                status: value
+                    .get("finish")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+            });
+        }
+    }
+}
+
+/// Tool calls are `part` rows of `type:"tool"`; the real tool name is the `tool`
+/// field (`glob` / `read` / `edit` / `bash` / an MCP name).
+fn parse_tool_parts(
+    conn: &Connection,
+    floor_ms: i64,
+    local_offset: UtcOffset,
+    collection: &mut Collection,
+) {
+    let Ok(mut stmt) = conn
+        .prepare("SELECT session_id, data FROM part WHERE json_extract(data, '$.type') = 'tool'")
+    else {
+        return;
+    };
+    let Ok(rows) = stmt.query_map([], |row| {
+        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+    }) else {
+        return;
+    };
+
+    for (session_id, data) in rows.flatten() {
+        collection.stats.lines_seen += 1;
+        let Ok(value) = serde_json::from_str::<Value>(&data) else {
+            collection.stats.parse_errors += 1;
+            continue;
+        };
+        let Some(tool_name) = value.get("tool").and_then(Value::as_str) else {
+            continue;
+        };
+        let start_ms = value.pointer("/state/time/start").and_then(Value::as_i64);
+        if start_ms.is_some_and(|ms| ms < floor_ms) {
+            continue;
+        }
+        collection.tool_events.push(ToolEvent {
+            timestamp: start_ms.and_then(|ms| ms_to_offset(ms, local_offset)),
+            session_id: Some(session_id),
+            tool_name: tool_name.to_owned(),
+            subagent_type: None,
+            source_kind: SourceKind::Main,
+        });
+    }
+}
+
+fn token(value: &Value, pointer: &str) -> u64 {
+    value.pointer(pointer).and_then(Value::as_u64).unwrap_or(0)
+}
+
+/// Epoch-milliseconds → local-offset `OffsetDateTime`.
+fn ms_to_offset(ms: i64, local_offset: UtcOffset) -> Option<OffsetDateTime> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(ms) * 1_000_000)
+        .ok()
+        .map(|time| time.to_offset(local_offset))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::Connection;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    const ASSISTANT_MS: i64 = 1_781_542_363_256;
+    const ASSISTANT_DONE_MS: i64 = 1_781_542_436_778;
+
+    fn write_db(dir: &Path) {
+        let conn = Connection::open(dir.join("opencode.db")).expect("open temp db");
+        conn.execute_batch(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);",
+        )
+        .expect("create schema");
+        let assistant = r#"{"role":"assistant","modelID":"qwen3:8b","path":{"cwd":"/somewhere/proj"},"tokens":{"input":100,"output":20,"reasoning":5,"cache":{"read":40,"write":10}},"time":{"created":1781542363256,"completed":1781542436778},"finish":"stop"}"#;
+        conn.execute(
+            "INSERT INTO message VALUES ('m1','s1',1781542363256,1781542436778,?1)",
+            [assistant],
+        )
+        .expect("insert assistant");
+        let user = r#"{"role":"user","time":{"created":1781542300000}}"#;
+        conn.execute(
+            "INSERT INTO message VALUES ('m0','s1',1781542300000,1781542300000,?1)",
+            [user],
+        )
+        .expect("insert user");
+        let tool = r#"{"type":"tool","tool":"glob","state":{"time":{"start":1781542400000,"end":1781542400500}}}"#;
+        conn.execute(
+            "INSERT INTO part VALUES ('p1','m1','s1',1781542400000,1781542400500,?1)",
+            [tool],
+        )
+        .expect("insert tool part");
+    }
+
+    #[test]
+    fn parses_tokens_tools_durations() {
+        let dir = TempDir::new().expect("tempdir");
+        write_db(dir.path());
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.provider, Provider::OpenCode);
+        assert_eq!(collection.usage_events.len(), 1);
+        let event = &collection.usage_events[0];
+        assert_eq!(event.usage.input_tokens, 100);
+        assert_eq!(event.usage.output_tokens, 20);
+        assert_eq!(event.usage.reasoning_output_tokens, 5);
+        assert_eq!(event.usage.cache_read_input_tokens, 40);
+        assert_eq!(event.usage.cache_creation_input_tokens, 10);
+        // token_volume = input + output + cache_create + cache_read (reasoning is
+        // a subset of output, not added on top).
+        assert_eq!(event.usage.token_volume(), 170);
+        assert_eq!(event.model.as_deref(), Some("qwen3:8b"));
+        assert_eq!(event.project.as_deref(), Some("somewhere/proj"));
+
+        assert_eq!(collection.tool_events.len(), 1);
+        assert_eq!(collection.tool_events[0].tool_name, "glob");
+
+        assert_eq!(collection.duration_events.len(), 1);
+        let expected = u64::try_from(ASSISTANT_DONE_MS - ASSISTANT_MS).unwrap();
+        assert_eq!(collection.duration_events[0].duration_ms, expected);
+
+        // A touch per message (user + assistant), for concurrency / active days.
+        assert_eq!(collection.session_touches.len(), 2);
+    }
+
+    #[test]
+    fn missing_db_is_empty() {
+        let dir = TempDir::new().expect("tempdir");
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert!(collection.usage_events.is_empty());
+        assert!(collection.tool_events.is_empty());
+        assert!(collection.session_touches.is_empty());
+    }
+
+    #[test]
+    fn mtime_floor_drops_events_before_the_window() {
+        let dir = TempDir::new().expect("tempdir");
+        write_db(dir.path());
+        // Floor sits after every event in the fixture.
+        let floor = std::time::UNIX_EPOCH + Duration::from_millis(1_781_542_500_000);
+        let collection = collect(dir.path(), Some(floor), false, UtcOffset::UTC);
+        assert!(collection.usage_events.is_empty());
+        assert!(collection.tool_events.is_empty());
+        assert!(collection.session_touches.is_empty());
+    }
+}

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -8,17 +8,18 @@
 //! (`type:"tool"`, `tool`). Storage layout is documented at
 //! <https://opencode.ai/docs/troubleshooting/> and the OSS repo (sst/opencode).
 //!
-//! We open the DB **read-only and immutable** (no locks, no WAL recovery) so
-//! agent-walker never touches the user's OpenCode store. Cost is left to the
-//! shared LiteLLM pricing path like every other provider — the per-message
-//! `cost` OpenCode records (and local models such as Ollama, which report no
-//! priced usage) is not used here.
+//! We read a **private snapshot copy** of the DB (copied to a temp dir, WAL and
+//! all) and never let SQLite open the user's live store, so we can't lock,
+//! checkpoint, or corrupt it. Cost is left to the shared LiteLLM pricing path
+//! like every other provider — the per-message `cost` OpenCode records (and
+//! local models such as Ollama, which report no priced usage) is not used here.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use rusqlite::{Connection, OpenFlags};
+use rusqlite::{Connection, params};
 use serde_json::Value;
+use tempfile::TempDir;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::collector::project_from_cwd;
@@ -38,7 +39,8 @@ pub fn collect(
     if !db_path.exists() {
         return collection;
     }
-    let Some(conn) = open_readonly(&db_path) else {
+    // `_snapshot` must outlive `conn` — it owns the temp copy `conn` reads.
+    let Some((conn, _snapshot)) = open_snapshot(&db_path) else {
         collection.stats.unreadable_files += 1;
         return collection;
     };
@@ -60,16 +62,31 @@ pub fn collect(
     collection
 }
 
-/// Open the DB read-only and immutable: SQLite takes no locks and never tries to
-/// recover the WAL, so a live OpenCode session can't be disturbed and we can't
-/// write to the user's store. Immutable reads the last-committed state.
-fn open_readonly(db: &Path) -> Option<Connection> {
-    let uri = format!("file:{}?immutable=1", db.to_string_lossy());
-    Connection::open_with_flags(
-        uri,
-        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_URI,
-    )
-    .ok()
+/// Copy the DB (plus any `-wal` / `-shm` sidecars) into a throwaway temp dir and
+/// open the *copy*. The user's store is only ever read via `fs::copy` — never
+/// opened by SQLite — so a live OpenCode session can't be locked, checkpointed,
+/// or corrupted, and copying the WAL keeps the snapshot consistent (no
+/// `immutable=1` foot-gun). The `TempDir` is returned so it outlives the
+/// connection and is removed on drop.
+fn open_snapshot(db: &Path) -> Option<(Connection, TempDir)> {
+    let snapshot = TempDir::new().ok()?;
+    let dest = snapshot.path().join("opencode.db");
+    std::fs::copy(db, &dest).ok()?;
+    for suffix in ["-wal", "-shm"] {
+        let sidecar = with_suffix(db, suffix);
+        if sidecar.exists() {
+            let _ = std::fs::copy(&sidecar, with_suffix(&dest, suffix));
+        }
+    }
+    Connection::open(&dest).ok().map(|conn| (conn, snapshot))
+}
+
+/// SQLite sidecar path: the DB filename with a suffix appended (`opencode.db`
+/// → `opencode.db-wal`). Appends to the whole path so non-UTF-8 names survive.
+fn with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut name = path.as_os_str().to_owned();
+    name.push(suffix);
+    PathBuf::from(name)
 }
 
 /// One usage + duration event per assistant message (the per-turn totals live on
@@ -80,10 +97,14 @@ fn parse_messages(
     local_offset: UtcOffset,
     collection: &mut Collection,
 ) {
-    let Ok(mut stmt) = conn.prepare("SELECT session_id, data FROM message") else {
+    // Filter on the indexed `time_created` column so SQLite skips out-of-window
+    // rows before we ever parse their JSON in Rust.
+    let Ok(mut stmt) =
+        conn.prepare("SELECT session_id, data FROM message WHERE time_created >= ?1")
+    else {
         return;
     };
-    let Ok(rows) = stmt.query_map([], |row| {
+    let Ok(rows) = stmt.query_map(params![floor_ms], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     }) else {
         return;
@@ -98,9 +119,6 @@ fn parse_messages(
         let Some(created_ms) = value.pointer("/time/created").and_then(Value::as_i64) else {
             continue;
         };
-        if created_ms < floor_ms {
-            continue;
-        }
         let Some(timestamp) = ms_to_offset(created_ms, local_offset) else {
             continue;
         };
@@ -142,7 +160,10 @@ fn parse_messages(
             collection.duration_events.push(DurationEvent {
                 timestamp: Some(timestamp),
                 session_id: Some(session_id),
-                duration_ms: u64::try_from(completed_ms - created_ms).unwrap_or(0),
+                // `time.completed` is untrusted; saturating_sub avoids an
+                // overflow panic, and a clock that ran backwards (completed <
+                // created) falls to 0 rather than a garbage duration.
+                duration_ms: u64::try_from(completed_ms.saturating_sub(created_ms)).unwrap_or(0),
                 status: value
                     .get("finish")
                     .and_then(Value::as_str)
@@ -160,12 +181,14 @@ fn parse_tool_parts(
     local_offset: UtcOffset,
     collection: &mut Collection,
 ) {
-    let Ok(mut stmt) = conn
-        .prepare("SELECT session_id, data FROM part WHERE json_extract(data, '$.type') = 'tool'")
-    else {
+    // `time_created >= ?1` first lets SQLite drop out-of-window rows on the cheap
+    // integer column before the per-row `json_extract` ever runs.
+    let Ok(mut stmt) = conn.prepare(
+        "SELECT session_id, data FROM part WHERE time_created >= ?1 AND json_extract(data, '$.type') = 'tool'",
+    ) else {
         return;
     };
-    let Ok(rows) = stmt.query_map([], |row| {
+    let Ok(rows) = stmt.query_map(params![floor_ms], |row| {
         Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
     }) else {
         return;
@@ -181,9 +204,6 @@ fn parse_tool_parts(
             continue;
         };
         let start_ms = value.pointer("/state/time/start").and_then(Value::as_i64);
-        if start_ms.is_some_and(|ms| ms < floor_ms) {
-            continue;
-        }
         collection.tool_events.push(ToolEvent {
             timestamp: start_ms.and_then(|ms| ms_to_offset(ms, local_offset)),
             session_id: Some(session_id),
@@ -292,5 +312,29 @@ mod tests {
         assert!(collection.usage_events.is_empty());
         assert!(collection.tool_events.is_empty());
         assert!(collection.session_touches.is_empty());
+    }
+
+    #[test]
+    fn backwards_clock_duration_is_zero() {
+        // A corrupt / skewed `time.completed` earlier than `time.created` must
+        // not overflow or produce a garbage duration — it falls to 0.
+        let dir = TempDir::new().expect("tempdir");
+        let conn = Connection::open(dir.path().join("opencode.db")).expect("open temp db");
+        conn.execute_batch(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);",
+        )
+        .expect("create schema");
+        let backwards = r#"{"role":"assistant","tokens":{"input":1,"output":1},"time":{"created":2000,"completed":1000}}"#;
+        conn.execute(
+            "INSERT INTO message VALUES ('m1','s1',2000,2000,?1)",
+            [backwards],
+        )
+        .expect("insert");
+        drop(conn);
+
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert_eq!(collection.duration_events.len(), 1);
+        assert_eq!(collection.duration_events[0].duration_ms, 0);
     }
 }

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -155,7 +155,13 @@ fn parse_messages(
         return;
     };
     let Ok(rows) = stmt.query_map(params![floor_ms], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        // `session_id` is NOT NULL in OpenCode's own schema, but a corrupt DB
+        // could still carry a NULL — default it rather than dropping the row
+        // (and its tokens) as a type-mismatch parse error.
+        Ok((
+            row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+            row.get::<_, String>(1)?,
+        ))
     }) else {
         return;
     };
@@ -245,7 +251,13 @@ fn parse_tool_parts(
         return;
     };
     let Ok(rows) = stmt.query_map(params![floor_ms], |row| {
-        Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        // `session_id` is NOT NULL in OpenCode's own schema, but a corrupt DB
+        // could still carry a NULL — default it rather than dropping the row
+        // (and its tokens) as a type-mismatch parse error.
+        Ok((
+            row.get::<_, Option<String>>(0)?.unwrap_or_default(),
+            row.get::<_, String>(1)?,
+        ))
     }) else {
         return;
     };
@@ -430,6 +442,31 @@ mod tests {
         assert!(collection.usage_events.is_empty());
         assert!(collection.tool_events.is_empty());
         assert!(collection.session_touches.is_empty());
+    }
+
+    #[test]
+    fn null_session_id_keeps_the_row() {
+        // A corrupt DB with a NULL session_id must not drop the row (and its
+        // tokens) as a parse error — it defaults to an empty session instead.
+        let dir = TempDir::new().expect("tempdir");
+        let conn = Connection::open(dir.path().join("opencode.db")).expect("open temp db");
+        conn.execute_batch(
+            "CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+             CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);",
+        )
+        .expect("create schema");
+        let assistant = r#"{"role":"assistant","tokens":{"input":7,"output":3},"time":{"created":1781542363256}}"#;
+        conn.execute(
+            "INSERT INTO message VALUES ('m1',NULL,1781542363256,1781542363256,?1)",
+            [assistant],
+        )
+        .expect("insert");
+        drop(conn);
+
+        let collection = collect(dir.path(), None, false, UtcOffset::UTC);
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.usage_events[0].usage.token_volume(), 10);
+        assert_eq!(collection.stats.parse_errors, 0);
     }
 
     #[test]

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -124,11 +124,16 @@ fn resolve_db_paths(root: &Path, override_db: Option<OsString>) -> Vec<PathBuf> 
 /// collection rather than touching the store.
 fn open_snapshot(db: &Path) -> Option<Connection> {
     let source = Connection::open_with_flags(db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    // If OpenCode holds a write lock as we attach, wait briefly rather than
+    // failing the snapshot outright.
+    let _ = source.busy_timeout(Duration::from_millis(500));
     let mut snapshot = Connection::open_in_memory().ok()?;
     {
         let backup = Backup::new(&source, &mut snapshot).ok()?;
+        // Pause between any step that hits BUSY/LOCKED so a contended copy backs
+        // off instead of spinning.
         backup
-            .run_to_completion(1024, Duration::from_millis(0), None)
+            .run_to_completion(1024, Duration::from_millis(25), None)
             .ok()?;
     }
     Some(snapshot)

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -101,6 +101,7 @@ fn resolve_db_paths(root: &Path, override_db: Option<OsString>) -> Vec<PathBuf> 
         .filter(|path| {
             let is_db = path
                 .extension()
+                .and_then(|ext| ext.to_str())
                 .is_some_and(|ext| ext.eq_ignore_ascii_case("db"));
             let named_opencode = path
                 .file_name()

--- a/src/model.rs
+++ b/src/model.rs
@@ -10,6 +10,7 @@ pub enum Provider {
     Claude,
     Codex,
     Agy,
+    OpenCode,
 }
 
 impl Provider {
@@ -19,6 +20,7 @@ impl Provider {
             Self::Claude => "Claude",
             Self::Codex => "Codex",
             Self::Agy => "Agy",
+            Self::OpenCode => "OpenCode",
         }
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -66,6 +66,22 @@ pub fn agy_home() -> Result<PathBuf> {
     Ok(home_dir()?.join(".gemini").join("antigravity-cli"))
 }
 
+/// Data directory OpenCode reads. `OPENCODE_HOME` overrides it; otherwise it
+/// follows the XDG data dir (`$XDG_DATA_HOME/opencode`, default
+/// `~/.local/share/opencode`), as documented at
+/// <https://opencode.ai/docs/troubleshooting/>. The SQLite store lives at
+/// `<root>/opencode.db`.
+pub fn opencode_home() -> Result<PathBuf> {
+    resolve_root(std::env::var_os("OPENCODE_HOME"), || {
+        let xdg = std::env::var_os("XDG_DATA_HOME").filter(|value| !value.is_empty());
+        let base = match xdg {
+            Some(value) => PathBuf::from(value),
+            None => home_dir()?.join(".local").join("share"),
+        };
+        Ok(base.join("opencode"))
+    })
+}
+
 /// Base directory for `agent-walker`'s parse cache. Stays at
 /// `<home>/.cache/agent-walker` on every platform so a macOS/Linux user
 /// upgrading does not lose their warmed cache; on Windows this resolves under

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -29,6 +29,7 @@ pub(super) fn provider_color(provider: Provider) -> Color {
         Provider::Claude => HOT,
         Provider::Codex => GREEN,
         Provider::Agy => BLUE,
+        Provider::OpenCode => PURPLE,
         Provider::Combined => GOLD,
     }
 }


### PR DESCRIPTION
## Summary

Adds **OpenCode** as a fourth provider. It stores everything in a local SQLite DB (`~/.local/share/opencode/opencode.db`), so this is the first DB-based collector — opened **read-only + immutable** so we never lock it, touch its WAL, or write to the user's store.

Near parity with Claude / Codex, all local:
- **tokens** (input / output / reasoning / cache read+write) per assistant message, from `message.data` JSON
- **model** (`modelID`), **project** (`path.cwd`), **duration** (`time.created`→`completed`)
- **tools** from `part` rows of `type:"tool"`
- **sessions / hourly / activity** from message timestamps

Auto-detected like Antigravity: the tab appears only when `opencode.db` exists; an empty provider is filtered out. `--opencode-dir` / `OPENCODE_HOME` / `$XDG_DATA_HOME` override the location.

## Why local (and what about Cursor)

Researched against TokenTracker + the local stores. OpenCode exposes full token data locally (documented OSS schema), so it fits agent-walker's local-only design cleanly. **Cursor** was deliberately left out: it keeps **no token usage locally** (conversation JSON + AI-code-lines only) — tokens are only reachable via its cloud dashboard API using the stored auth token, which breaks the local-only model. Deferred.

## Notes

- New dep: `rusqlite` (bundled SQLite — builds on macOS / Linux / Windows without a system lib).
- `clippy.toml` whitelists product names (OpenCode / SQLite / LiteLLM / Ollama) for `doc_markdown`.
- Cost: priced via the shared LiteLLM path like other providers; local models (Ollama) show \$0 cost but their tokens count.

## Test

`cargo test` — 59 passing (3 new collector tests over a temp SQLite fixture: token/tool/duration parsing, missing-DB, mtime-floor). `cargo clippy --all-targets -- -D warnings` clean. `cargo fmt --check` clean. Verified on real data: OpenCode tab appears with tokens/sessions/tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)