### PR TITLE
Read Antigravity token usage from its conversation SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Antigravity token usage. Previously activity-only, it now reads real per-model
+  token counts (input / cache-read / output / thinking), model, and project from
+  the CLI's per-conversation SQLite stores (`conversations/*.db`). The data is an
+  unlabeled protobuf decoded by field number and **self-verified per row** (the
+  stored output total must equal text + thinking), so a future format change
+  degrades to less data, never wrong numbers. Cost still shows $0 — its gemini
+  model ids aren't in the pricing table yet.
+
 ## [0.5.0] - 2026-06-23
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -76,7 +76,7 @@ bunx agent-walker
 |---|---|---|
 | Claude Code | `~/.claude/projects/**/*.jsonl` | トークン / モデル / ツール / サブエージェント / プロジェクト / ターン時間 — [詳細](docs/claude.md) |
 | Codex CLI | `~/.codex/sessions/**/*.jsonl` | トークン / モデル / ツール / タスク時間 / プロジェクト — [詳細](docs/codex.md) |
-| Antigravity CLI | `~/.gemini/antigravity-cli` | 自動検出（ログがあるときだけタブ表示）。セッションとツールの流れのみ（ログにトークンなし） — [詳細](docs/agy.md) |
+| Antigravity CLI | `~/.gemini/antigravity-cli` | 自動検出。会話ごとの SQLite（ラベル無し protobuf をフィールド番号でデコード・行ごとに自己検証）からトークン/モデル/プロジェクト、ログから activity/ツール。コストは $0（gemini の id が未価格） — [詳細](docs/agy.md) |
 
 各エージェントはトークンとキャッシュの数え方が違う。上の per-agent ページに、何を読むか・トークン/キャッシュ/コストの数え方・注意点を書いてある（英語）。
 
@@ -96,7 +96,7 @@ Claude Code は既定で**約30日でトランスクリプトを整理する**�
 
 - コストは **API 換算の見積もり**（実請求ではない）。LiteLLM の価格、キャッシュ読み書きは別レート。pricing fetch 日付は、pricing が読めて端末幅に余裕があるとき COST パネルに表示される。
 - トークンは**キャッシュ込み**（入力 + 出力 + キャッシュ書込 + 読込）。Claude は毎ターン全コンテキストを再送するので、ヘビーに使うほど合計の大部分はキャッシュ読込＝安価な再読込で、新規の作業量とは別物。
-- **Antigravity はトークン/コスト非計上**（中身不明な protobuf）。タブは自動検出されるが、Total の合計トークンには加算されない（活動のみ反映）。
+- **Antigravity のトークンはラベル無し protobuf（会話ごと SQLite）から読む**。フィールド番号でデコードし行ごとに自己検証するので合計に加算される。ただしコストは $0（gemini の id が価格表に未対応）。
 - 各エージェント自身の利用表示とは一致しない（集計の窓やキャッシュの数え方が違う）。
 - Antigravity のログのタイムスタンプはタイムゾーンなし＝ローカル想定。
 - Windows バイナリは 0.3 以降で配布。Windows Terminal / PowerShell で動き、ログは `%USERPROFILE%` から読む。WSL でもそのまま動く（パスは Linux 形式のまま）。

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ card — just glance before you post.
 | Claude Code | `~/.claude/projects/**/*.jsonl` | tokens, models, tools, subagents, projects, turn durations — [details](docs/claude.md) |
 | Codex CLI | `~/.codex/sessions/**/*.jsonl` | tokens, models, tools, task durations, projects — [details](docs/codex.md) |
 | OpenCode | `~/.local/share/opencode/opencode*.db` | auto-detected (SQLite, read-only snapshot; honors `OPENCODE_DB`); tokens, models, tools, durations, projects — [details](docs/opencode.md) |
-| Antigravity CLI | `~/.gemini/antigravity-cli` | auto-detected (tab shows only if logs exist); sessions and tool flow only — no token data in its logs — [details](docs/agy.md) |
+| Antigravity CLI | `~/.gemini/antigravity-cli` | auto-detected; tokens, models, and projects from its per-conversation SQLite (an unlabeled protobuf, decoded by field number and self-verified per row), plus activity/tools from the logs. Cost shows $0 — its gemini model ids aren't priced yet — [details](docs/agy.md) |
 
 Each agent counts and caches tokens differently. The per-agent pages above
 explain what's read, how tokens/cache/cost are counted, and the caveats.
@@ -130,9 +130,10 @@ indefinitely; no setting needed.
   reads). Claude Code re-sends the full context every turn, so for heavy
   users the bulk of the total tends to be cache reads — real but cheaply
   billed context re-reads, not new work. See [docs/claude.md](docs/claude.md).
-- **Antigravity tokens/cost are not counted** — its usage lives in an
-  undocumented protobuf format. Its tab is auto-detected, but the Total token
-  count still excludes it (activity only); see [docs/agy.md](docs/agy.md).
+- **Antigravity tokens are read from an undocumented protobuf** (its
+  per-conversation SQLite), decoded by field number and self-verified per row, so
+  they count toward the totals. Its **cost still shows $0** — its gemini model
+  ids aren't in the pricing table yet; see [docs/agy.md](docs/agy.md).
 - These numbers **won't match each agent's own in-app usage display**: those use
   different time windows and count cache reads differently. See the per-agent
   pages above.

--- a/docs/agy.md
+++ b/docs/agy.md
@@ -2,28 +2,40 @@
 
 ## Where the data comes from
 
-`~/.gemini/antigravity-cli` — `history.jsonl` (timestamps) and `log/cli-*.log`
-(model name + confirmed commands). Read-only. Auto-detected: the Agy tab appears
-only when this directory holds logs (point elsewhere with `--agy-dir`).
+`~/.gemini/antigravity-cli` (read-only, auto-detected; point elsewhere with
+`--agy-dir`):
 
-## What's captured — and what isn't
+- `history.jsonl` + `log/cli-*.log` → the session / tool **activity** timeline.
+- `conversations/<uuid>.db` (SQLite) → **token usage, model, and project**, one
+  row per generation in the `gen_metadata` table.
 
-- ✅ **Activity**: session timestamps → active days, hourly profile, streak.
-- ✅ **Model**: the model name from the CLI log.
-- ✅ **Some tools**: only the commands you *confirmed* in approval dialogs
-  (`command:<exe>`).
-- ❌ **Tokens and cost are not captured.** agy reports ~0 tokens and $0.
+## What's captured
 
-## Why tokens are missing (design constraint)
+- ✅ **Tokens** — per generation: input (system prompt + new input), cache-read,
+  output (text), and thinking/reasoning. Thinking is folded into output so it
+  counts toward the total (same convention as OpenCode).
+- ✅ **Model** — e.g. `gemini-3-flash-agent`.
+- ✅ **Project** — the workspace path recorded in the conversation.
+- ✅ **Activity** — session timestamps → active days, hourly profile, streak.
+- ✅ **Some tools** — the commands you *confirmed* in approval dialogs
+  (`command:<exe>`) from the logs.
 
-Antigravity's real usage data lives in `.db` / `.pb` files as **protobuf blobs**
-that need Antigravity's private `.proto` schema to decode. That schema is
-undocumented and changes between versions, so parsing it would be fragile and
-break often. agent-walker deliberately does **not** read it.
+## The tokens are unlabeled protobuf — and self-verified
 
-## What this means
+`gen_metadata` rows are Antigravity's internal **protobuf with no field names**,
+and there's no public schema. agent-walker reads the wire format directly and
+pulls the few fields it needs by number (cross-checked against the `tokscale`
+project, which maps them identically). Because the numbers are unofficial and
+could shift on an Antigravity update, **every row is self-verified**: the stored
+output total must equal text + thinking. A row that fails is skipped and counted
+as a parse error rather than contributing garbage tokens — so a future format
+change degrades to "no/less data," never to wrong numbers. See
+`src/collector/agy_conv.rs`.
 
-Treat agy numbers as **activity-only**. If you use Antigravity meaningfully, its
-tokens and cost are **not** reflected in agent-walker's totals — including the
-Total view. This is a known gap, not a bug: it is the price of not coupling to
-an undocumented binary format.
+## Cost
+
+Cost is **not** shown yet. Antigravity's model ids (`gemini-3-flash-agent`, …)
+don't match the LiteLLM pricing table's ids, and the pricing path is currently
+limited to `claude-*` / `gpt-*` models, so gemini usage prices to nothing. Tokens
+still count toward the totals; only the COST panel is blank for Antigravity (the
+same way OpenCode's local Ollama models count tokens but show $0).

--- a/src/collector/agy.rs
+++ b/src/collector/agy.rs
@@ -1,16 +1,13 @@
-//! Antigravity (`agy`) collector — **auto-detected; the tab shows only when
-//! logs are present, and carries activity only (no token usage).**
+//! Antigravity (`agy`) collector — **auto-detected; shows when local data is
+//! present.**
 //!
-//! Why activity-only: Antigravity's text logs (`log/*.log`, `history.jsonl`)
-//! record the model, turns, and tool confirmations but **no token usage**, so
-//! every event here carries `TokenUsage::default()` (zero). The real usage lives
-//! in `conversations/*.{db,pb}` as unlabeled protobuf blobs (table
-//! `gen_metadata`) — token-magnitude integers are present but which field is
-//! prompt / output / cached is unknown, and the schema is Google-internal and
-//! liable to change. Because every agy event is zero-token, it never moves the
-//! token totals; the tab simply appears when logs exist and sorts last. This
-//! parser is kept intact for the day that store becomes readable (decode
-//! `gen_metadata`, identify the token fields, fill `usage`).
+//! Two sources: the text logs (`log/*.log`, `history.jsonl`) give the session /
+//! tool activity timeline, and the per-conversation SQLite stores
+//! (`conversations/*.db`) give the real token usage, model, and project — see
+//! [`super::agy_conv`], which decodes the unlabeled `gen_metadata` protobuf and
+//! self-verifies the field map. Tokens used to be unavailable (the store was
+//! left unparsed), so this collector was activity-only; it now contributes full
+//! usage like the others.
 
 use std::fs::File;
 use std::io::{BufRead, BufReader};
@@ -20,12 +17,8 @@ use std::time::SystemTime;
 use serde_json::Value;
 use time::{Date, Month, OffsetDateTime, PrimitiveDateTime, Time, UtcOffset};
 
-use crate::collector::{
-    FileEvents, KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached,
-};
-use crate::model::{
-    Collection, Provider, SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
-};
+use crate::collector::{FileEvents, KeyedToolEvent, list_files, merge_into, parse_files_cached};
+use crate::model::{Collection, Provider, SessionTouch, SourceKind, ToolEvent};
 
 pub fn collect(
     root: &Path,
@@ -57,6 +50,14 @@ pub fn collect(
         parse_file(path, local_offset)
     });
     merge_into(&mut collection, per_file);
+
+    // Real token usage comes from the per-conversation SQLite stores, not the
+    // text logs (which only carry activity). The logs above still provide the
+    // session/tool timeline; these add tokens, model, and project.
+    let usage =
+        super::agy_conv::collect_usage(root, mtime_floor, local_offset, &mut collection.stats);
+    collection.usage_events.extend(usage);
+    collection.stats.usage_events = collection.usage_events.len();
     collection
 }
 
@@ -116,7 +117,6 @@ fn parse_log_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
     let file = File::open(path).ok()?;
     let mut events = FileEvents::default();
     let log_session_id = fallback_session_id(path);
-    let mut current_model = None;
     let mut current_conversation_id = None;
     let reader = BufReader::new(file);
 
@@ -127,33 +127,17 @@ fn parse_log_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
             continue;
         };
         let timestamp = parse_log_timestamp(path, &line, local_offset);
-        if line.contains("model_config_manager.go")
-            && let Some(model) = quoted_value(&line, "label=\"")
-        {
-            current_model = Some(model);
-            continue;
-        }
 
         if line.contains("HandleUserInput called with text") {
             let session_id = current_conversation_id
                 .clone()
                 .or_else(|| log_session_id.clone());
+            // Activity only — real tokens/model come from conversations/*.db
+            // (see `agy_conv`), so no zero-token usage event is emitted here.
             if let (Some(timestamp), Some(session_id)) = (timestamp, session_id) {
                 events.session_touches.push(SessionTouch {
                     timestamp,
-                    session_id: session_id.clone(),
-                });
-                events.usage_events.push(KeyedUsageEvent {
-                    key: None,
-                    event: UsageEvent {
-                        timestamp: Some(timestamp),
-                        session_id: Some(session_id),
-                        model: current_model.clone().or_else(|| Some("Gemini".to_owned())),
-                        source_kind: SourceKind::Main,
-                        attribution_agent: None,
-                        project: None,
-                        usage: TokenUsage::default(),
-                    },
+                    session_id,
                 });
             }
             continue;
@@ -218,18 +202,6 @@ fn log_year(path: &Path) -> Option<i32> {
     let file_stem = path.file_stem()?.to_str()?;
     let raw_date = file_stem.strip_prefix("cli-")?.get(0..8)?;
     raw_date.get(0..4)?.parse::<i32>().ok()
-}
-
-fn quoted_value(line: &str, marker: &str) -> Option<String> {
-    let start = line.find(marker)? + marker.len();
-    let rest = line.get(start..)?;
-    let end = rest.find('"')?;
-    let value = rest.get(0..end)?;
-    if value.is_empty() {
-        None
-    } else {
-        Some(value.to_owned())
-    }
 }
 
 fn value_after(line: &str, marker: &str) -> Option<String> {
@@ -307,12 +279,9 @@ mod tests {
         let collection = collect(temp.path(), None, false, UtcOffset::UTC);
 
         assert_eq!(collection.stats.files_seen, 2);
-        assert_eq!(collection.usage_events.len(), 1);
-        assert_eq!(
-            collection.usage_events[0].model.as_deref(),
-            Some("Gemini 3.5 Flash (High)")
-        );
-        assert_eq!(collection.usage_events[0].usage.token_volume(), 0);
+        // The text logs are activity/tools only — token usage now comes from
+        // conversations/*.db (none in this fixture), so no usage events here.
+        assert!(collection.usage_events.is_empty());
         assert_eq!(collection.tool_events[0].tool_name, "command:bun");
         assert!(collection.session_touches.len() >= 2);
     }

--- a/src/collector/agy_conv.rs
+++ b/src/collector/agy_conv.rs
@@ -24,10 +24,12 @@
 //! ```
 //!
 //! Because the numbers are unofficial and could shift on an Antigravity update,
-//! every row is self-verified: the precomputed output total `#3` must equal
-//! `#9 + #10`. A mismatch means the layout drifted, so the row is skipped and
-//! counted as a parse error rather than emitting garbage tokens.
+//! every row is self-verified against the precomputed output total `#3`: it must
+//! equal `#9 + #10`. A mismatch means the layout drifted → the row is dropped and
+//! counted as a parse error. A row that omits `#3` can't be verified, so it's
+//! skipped too, but quietly (some healthy rows omit it — not an error).
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -62,28 +64,60 @@ pub(super) fn collect_usage(
         .collect();
     dbs.sort();
 
+    // Dedupe retried generations (same response id) across every DB, so a retry
+    // never double-counts.
+    let mut seen = HashSet::new();
     for db in dbs {
+        let newest = newest_mtime_ms(&db);
         // Skip whole files older than the window (cheap mtime gate, like the
-        // JSONL collectors) so a long history doesn't reparse every run.
-        if let (Some(floor_ms), Ok(meta)) = (floor, std::fs::metadata(&db))
-            && meta
-                .modified()
-                .ok()
-                .and_then(systemtime_to_ms)
-                .is_some_and(|mtime| mtime < floor_ms)
+        // JSONL collectors) so a long history doesn't reparse every run. In WAL
+        // mode recent writes land in `<db>-wal`, so gate on the newest of the DB
+        // and its sidecars, not the main file alone.
+        if let (Some(floor_ms), Some(mtime)) = (floor, newest)
+            && mtime < floor_ms
         {
             continue;
         }
-        parse_db(&db, floor, local_offset, stats, &mut events);
+        parse_db(
+            &db,
+            floor,
+            newest,
+            local_offset,
+            stats,
+            &mut seen,
+            &mut events,
+        );
     }
     events
+}
+
+/// Newest mtime (ms) across the DB and its `-wal` / `-shm` sidecars.
+fn newest_mtime_ms(db: &Path) -> Option<i64> {
+    ["", "-wal", "-shm"]
+        .iter()
+        .filter_map(|suffix| {
+            let path = if suffix.is_empty() {
+                db.to_path_buf()
+            } else {
+                let mut name = db.as_os_str().to_owned();
+                name.push(suffix);
+                std::path::PathBuf::from(name)
+            };
+            std::fs::metadata(path)
+                .ok()
+                .and_then(|meta| meta.modified().ok())
+                .and_then(systemtime_to_ms)
+        })
+        .max()
 }
 
 fn parse_db(
     db: &Path,
     floor_ms: Option<i64>,
+    db_mtime_ms: Option<i64>,
     local_offset: UtcOffset,
     stats: &mut ScanStats,
+    seen: &mut HashSet<String>,
     events: &mut Vec<UsageEvent>,
 ) {
     let Some(conn) = open_readonly(db) else {
@@ -97,6 +131,14 @@ fn parse_db(
         .unwrap_or("antigravity")
         .to_owned();
     let (session_ts, project) = trajectory_meta(&conn);
+    // Fallback chain for a row's time: its own stamp → the conversation's
+    // created-at → the DB file mtime (so a missing timestamp dates the event near
+    // when the file was written, never 1970).
+    let fallback_ts = if session_ts > 0 {
+        session_ts
+    } else {
+        db_mtime_ms.unwrap_or(0)
+    };
 
     let Ok(mut stmt) = conn.prepare("SELECT data FROM gen_metadata ORDER BY idx") else {
         return;
@@ -113,15 +155,16 @@ fn parse_db(
         match parse_gen(
             &blob,
             &session_id,
-            session_ts,
+            fallback_ts,
             project.as_deref(),
             local_offset,
+            seen,
         ) {
             ParseGen::Event(event) => {
                 if floor_ms.is_some_and(|floor| {
                     event
                         .timestamp
-                        .is_some_and(|ts| ts.unix_timestamp() * 1000 < floor)
+                        .is_some_and(|ts| ts.unix_timestamp_nanos() / 1_000_000 < i128::from(floor))
                 }) {
                     continue;
                 }
@@ -142,9 +185,10 @@ enum ParseGen {
 fn parse_gen(
     blob: &[u8],
     session_id: &str,
-    session_ts_ms: i64,
+    fallback_ts_ms: i64,
     project: Option<&str>,
     local_offset: UtcOffset,
+    seen: &mut HashSet<String>,
 ) -> ParseGen {
     let Some(chat_model) = message_field(blob, 1) else {
         return ParseGen::Empty;
@@ -163,12 +207,16 @@ fn parse_gen(
     let output_text = to_u64(v(9));
     let thinking = to_u64(v(10));
 
-    // Self-verify the field map: the stored output total (#3) must equal
-    // text + thinking. If it doesn't, the layout drifted — refuse the row.
-    if let Some(total) = varint_field(usage, 3)
-        && to_u64(total) != output_text.saturating_add(thinking)
-    {
-        return ParseGen::Drift;
+    // Self-verify the field map against the stored output total (#3):
+    // - present and == text + thinking → trusted.
+    // - present but != → the layout drifted; flag it (Drift → parse error).
+    // - absent → can't verify this row, so don't trust it, but absence happens in
+    //   healthy data (some rows omit #3), so skip it quietly rather than as an
+    //   error.
+    match varint_field(usage, 3) {
+        Some(total) if to_u64(total) == output_text.saturating_add(thinking) => {}
+        Some(_) => return ParseGen::Drift,
+        None => return ParseGen::Empty,
     }
 
     let input = system.saturating_add(new_input);
@@ -176,11 +224,18 @@ fn parse_gen(
         return ParseGen::Empty;
     }
 
+    // Skip a retried generation already counted (same response id, field #11).
+    if let Some(id) = string_field(usage, 11).filter(|id| !id.trim().is_empty())
+        && !seen.insert(id.to_owned())
+    {
+        return ParseGen::Empty;
+    }
+
     let timestamp = message_field(chat_model, 9)
         .and_then(|node| message_field(node, 4))
         .and_then(proto_timestamp_ms)
         .filter(|&ms| ms > 0)
-        .unwrap_or(session_ts_ms);
+        .unwrap_or(fallback_ts_ms);
     let timestamp = ms_to_offset(timestamp, local_offset);
 
     let model = string_field(chat_model, 19)
@@ -225,8 +280,22 @@ fn trajectory_meta(conn: &Connection) -> (i64, Option<String>) {
         .unwrap_or(0);
     let project = message_field(&blob, 1)
         .and_then(|folder| string_field(folder, 1))
-        .map(|uri| uri.trim_start_matches("file://").to_owned());
+        .map(file_uri_to_path);
     (ts, project)
+}
+
+/// `file:///Users/me/x` → `/Users/me/x`; `file:///C:/Users/me/x` →
+/// `C:/Users/me/x` (drop the slash Windows leaves before the drive letter).
+fn file_uri_to_path(uri: &str) -> String {
+    let path = uri.trim_start_matches("file://");
+    // A Windows drive path is `/C:/...`; strip the leading slash so it reads as
+    // `C:/...`. Unix paths (`/Users/...`) keep their leading slash.
+    let bytes = path.as_bytes();
+    if bytes.len() >= 3 && bytes[0] == b'/' && bytes[2] == b':' && bytes[1].is_ascii_alphabetic() {
+        path[1..].to_owned()
+    } else {
+        path.to_owned()
+    }
 }
 
 fn open_readonly(db: &Path) -> Option<Connection> {
@@ -370,37 +439,46 @@ mod tests {
         out
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn gen_blob(
         system: u64,
         input: u64,
         cache: u64,
         output: u64,
         think: u64,
-        total: u64,
+        total: Option<u64>,
+        resp_id: &str,
     ) -> Vec<u8> {
         let mut usage = Vec::new();
         usage.extend(varint(1, system));
         usage.extend(varint(2, input));
-        usage.extend(varint(3, total));
+        if let Some(total) = total {
+            usage.extend(varint(3, total));
+        }
         usage.extend(varint(5, cache));
         usage.extend(varint(9, output));
         usage.extend(varint(10, think));
-        usage.extend(lenf(11, b"resp-1"));
+        usage.extend(lenf(11, resp_id.as_bytes()));
         let mut chat = Vec::new();
         chat.extend(lenf(4, &usage));
         chat.extend(lenf(19, b"gemini-3-flash"));
         lenf(1, &chat)
     }
 
+    fn parse(blob: &[u8]) -> ParseGen {
+        parse_gen(blob, "s1", 1, None, UtcOffset::UTC, &mut HashSet::new())
+    }
+
     #[test]
     fn maps_tokens_and_model() {
-        let blob = gen_blob(1132, 500, 16000, 300, 40, 340);
+        let blob = gen_blob(1132, 500, 16000, 300, 40, Some(340), "r1");
         let ParseGen::Event(e) = parse_gen(
             &blob,
             "s1",
             1_700_000_000_000,
             Some("/x/proj"),
             UtcOffset::UTC,
+            &mut HashSet::new(),
         ) else {
             panic!("expected event");
         };
@@ -414,19 +492,45 @@ mod tests {
     #[test]
     fn self_verify_rejects_drifted_total() {
         // #3 (999) != #9 + #10 (300 + 40) → layout drift → Drift, not garbage.
-        let blob = gen_blob(1132, 500, 0, 300, 40, 999);
+        let blob = gen_blob(1132, 500, 0, 300, 40, Some(999), "r1");
+        assert!(matches!(parse(&blob), ParseGen::Drift));
+    }
+
+    #[test]
+    fn missing_output_total_is_skipped_quietly() {
+        // No #3 at all → can't self-verify → skip (not trusted), but quietly:
+        // some healthy rows omit it, so it's not an error.
+        let blob = gen_blob(1132, 500, 0, 300, 40, None, "r1");
+        assert!(matches!(parse(&blob), ParseGen::Empty));
+    }
+
+    #[test]
+    fn duplicate_response_id_is_skipped() {
+        let blob = gen_blob(1132, 500, 0, 300, 40, Some(340), "dup");
+        let mut seen = HashSet::new();
         assert!(matches!(
-            parse_gen(&blob, "s1", 1, None, UtcOffset::UTC),
-            ParseGen::Drift
+            parse_gen(&blob, "s1", 1, None, UtcOffset::UTC, &mut seen),
+            ParseGen::Event(_)
+        ));
+        // Same response id again (a retry) → not counted twice.
+        assert!(matches!(
+            parse_gen(&blob, "s1", 1, None, UtcOffset::UTC, &mut seen),
+            ParseGen::Empty
         ));
     }
 
     #[test]
     fn all_zero_is_empty() {
-        let blob = gen_blob(0, 0, 0, 0, 0, 0);
-        assert!(matches!(
-            parse_gen(&blob, "s1", 1, None, UtcOffset::UTC),
-            ParseGen::Empty
-        ));
+        let blob = gen_blob(0, 0, 0, 0, 0, Some(0), "r1");
+        assert!(matches!(parse(&blob), ParseGen::Empty));
+    }
+
+    #[test]
+    fn windows_file_uri_drops_the_drive_slash() {
+        assert_eq!(
+            file_uri_to_path("file:///C:/Users/me/repo"),
+            "C:/Users/me/repo"
+        );
+        assert_eq!(file_uri_to_path("file:///Users/me/repo"), "/Users/me/repo");
     }
 }

--- a/src/collector/agy_conv.rs
+++ b/src/collector/agy_conv.rs
@@ -1,0 +1,432 @@
+//! Antigravity token usage from the CLI's per-conversation SQLite stores.
+//!
+//! Antigravity's text logs carry activity but no token counts; the real usage
+//! lives in `<root>/conversations/<uuid>.db`, table `gen_metadata` — one row per
+//! generation, each an **unlabeled protobuf** (no field names). There's no
+//! public schema, so this reads the wire format directly and pulls only the
+//! fields it needs. The field numbers were reverse-engineered (cross-checked
+//! against the `tokscale` project, which maps them the same way):
+//!
+//! ```text
+//! gen_metadata.#1                  chatModel message
+//!   #4                             usage message
+//!     #1  varint  fixed system-prompt tokens (~1132, billable input)
+//!     #2  varint  newly-processed (non-cached) input tokens
+//!     #3  varint  output total (== #9 + #10) — used only as a self-check
+//!     #5  varint  cacheRead tokens (only once a cached prefix exists)
+//!     #9  varint  output (visible text) tokens
+//!     #10 varint  thinking / reasoning tokens
+//!     #11 string  response id (dedup key)
+//!   #9.#4                          per-generation {#1 sec, #2 nanos} timestamp
+//!   #19 string                     model id
+//! trajectory_metadata_blob.#1.#1   workspace URI (project)
+//! trajectory_metadata_blob.#2      {#1 sec, #2 nanos} session-created timestamp
+//! ```
+//!
+//! Because the numbers are unofficial and could shift on an Antigravity update,
+//! every row is self-verified: the precomputed output total `#3` must equal
+//! `#9 + #10`. A mismatch means the layout drifted, so the row is skipped and
+//! counted as a parse error rather than emitting garbage tokens.
+
+use std::path::Path;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rusqlite::{Connection, OpenFlags};
+use time::{OffsetDateTime, UtcOffset};
+
+use crate::collector::project_from_cwd;
+use crate::model::{ScanStats, SourceKind, TokenUsage, UsageEvent};
+
+/// Read every `conversations/*.db` under `root` and return real token usage
+/// events. `stats` accumulates files/rows/parse-errors. Falls back gracefully
+/// (empty) when the directory or a DB is unreadable.
+pub(super) fn collect_usage(
+    root: &Path,
+    mtime_floor: Option<SystemTime>,
+    local_offset: UtcOffset,
+    stats: &mut ScanStats,
+) -> Vec<UsageEvent> {
+    let mut events = Vec::new();
+    let floor = mtime_floor.and_then(systemtime_to_ms);
+    let conversations = root.join("conversations");
+    let Ok(entries) = std::fs::read_dir(&conversations) else {
+        return events;
+    };
+    let mut dbs: Vec<_> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.extension()
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("db"))
+        })
+        .collect();
+    dbs.sort();
+
+    for db in dbs {
+        // Skip whole files older than the window (cheap mtime gate, like the
+        // JSONL collectors) so a long history doesn't reparse every run.
+        if let (Some(floor_ms), Ok(meta)) = (floor, std::fs::metadata(&db))
+            && meta
+                .modified()
+                .ok()
+                .and_then(systemtime_to_ms)
+                .is_some_and(|mtime| mtime < floor_ms)
+        {
+            continue;
+        }
+        parse_db(&db, floor, local_offset, stats, &mut events);
+    }
+    events
+}
+
+fn parse_db(
+    db: &Path,
+    floor_ms: Option<i64>,
+    local_offset: UtcOffset,
+    stats: &mut ScanStats,
+    events: &mut Vec<UsageEvent>,
+) {
+    let Some(conn) = open_readonly(db) else {
+        stats.unreadable_files += 1;
+        return;
+    };
+    stats.files_seen += 1;
+    let session_id = db
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("antigravity")
+        .to_owned();
+    let (session_ts, project) = trajectory_meta(&conn);
+
+    let Ok(mut stmt) = conn.prepare("SELECT data FROM gen_metadata ORDER BY idx") else {
+        return;
+    };
+    let Ok(rows) = stmt.query_map([], |row| row.get::<_, Vec<u8>>(0)) else {
+        return;
+    };
+    for row in rows {
+        stats.lines_seen += 1;
+        let Ok(blob) = row else {
+            stats.parse_errors += 1;
+            continue;
+        };
+        match parse_gen(
+            &blob,
+            &session_id,
+            session_ts,
+            project.as_deref(),
+            local_offset,
+        ) {
+            ParseGen::Event(event) => {
+                if floor_ms.is_some_and(|floor| {
+                    event
+                        .timestamp
+                        .is_some_and(|ts| ts.unix_timestamp() * 1000 < floor)
+                }) {
+                    continue;
+                }
+                events.push(*event);
+            }
+            ParseGen::Empty => {}
+            ParseGen::Drift => stats.parse_errors += 1,
+        }
+    }
+}
+
+enum ParseGen {
+    Event(Box<UsageEvent>),
+    Empty,
+    Drift,
+}
+
+fn parse_gen(
+    blob: &[u8],
+    session_id: &str,
+    session_ts_ms: i64,
+    project: Option<&str>,
+    local_offset: UtcOffset,
+) -> ParseGen {
+    let Some(chat_model) = message_field(blob, 1) else {
+        return ParseGen::Empty;
+    };
+    let Some(usage) = message_field(chat_model, 4) else {
+        return ParseGen::Empty;
+    };
+
+    // Clamp untrusted u64 varints into i64 (a corrupt blob could exceed i64::MAX)
+    // and combine with saturating arithmetic so totals never wrap negative.
+    let v = |field: u64| varint_field(usage, field).unwrap_or(0);
+    let to_u64 = |x: u64| x.min(i64::MAX as u64);
+    let system = to_u64(v(1));
+    let new_input = to_u64(v(2));
+    let cache_read = to_u64(v(5));
+    let output_text = to_u64(v(9));
+    let thinking = to_u64(v(10));
+
+    // Self-verify the field map: the stored output total (#3) must equal
+    // text + thinking. If it doesn't, the layout drifted — refuse the row.
+    if let Some(total) = varint_field(usage, 3)
+        && to_u64(total) != output_text.saturating_add(thinking)
+    {
+        return ParseGen::Drift;
+    }
+
+    let input = system.saturating_add(new_input);
+    if input == 0 && output_text == 0 && cache_read == 0 && thinking == 0 {
+        return ParseGen::Empty;
+    }
+
+    let timestamp = message_field(chat_model, 9)
+        .and_then(|node| message_field(node, 4))
+        .and_then(proto_timestamp_ms)
+        .filter(|&ms| ms > 0)
+        .unwrap_or(session_ts_ms);
+    let timestamp = ms_to_offset(timestamp, local_offset);
+
+    let model = string_field(chat_model, 19)
+        .filter(|text| !text.trim().is_empty())
+        .map(ToOwned::to_owned);
+
+    let usage = TokenUsage {
+        input_tokens: input,
+        // Fold thinking into output so token_volume() counts it (same convention
+        // as the OpenCode collector); reasoning is kept separately for display.
+        output_tokens: output_text.saturating_add(thinking),
+        reasoning_output_tokens: thinking,
+        cache_read_input_tokens: cache_read,
+        ..TokenUsage::default()
+    };
+    ParseGen::Event(Box::new(UsageEvent {
+        timestamp,
+        session_id: Some(session_id.to_owned()),
+        model,
+        source_kind: SourceKind::Main,
+        attribution_agent: None,
+        project: project.map(project_from_cwd),
+        usage,
+    }))
+}
+
+/// `trajectory_metadata_blob` carries the session-created timestamp (`#2`) and
+/// the workspace URI (`#1.#1`, used as the project label).
+fn trajectory_meta(conn: &Connection) -> (i64, Option<String>) {
+    let blob: Option<Vec<u8>> = conn
+        .query_row(
+            "SELECT data FROM trajectory_metadata_blob LIMIT 1",
+            [],
+            |row| row.get(0),
+        )
+        .ok();
+    let Some(blob) = blob else {
+        return (0, None);
+    };
+    let ts = message_field(&blob, 2)
+        .and_then(proto_timestamp_ms)
+        .unwrap_or(0);
+    let project = message_field(&blob, 1)
+        .and_then(|folder| string_field(folder, 1))
+        .map(|uri| uri.trim_start_matches("file://").to_owned());
+    (ts, project)
+}
+
+fn open_readonly(db: &Path) -> Option<Connection> {
+    let conn = Connection::open_with_flags(db, OpenFlags::SQLITE_OPEN_READ_ONLY).ok()?;
+    let _ = conn.busy_timeout(Duration::from_millis(500));
+    Some(conn)
+}
+
+fn systemtime_to_ms(time: SystemTime) -> Option<i64> {
+    let nanos = time.duration_since(UNIX_EPOCH).ok()?.as_millis();
+    i64::try_from(nanos).ok()
+}
+
+fn ms_to_offset(ms: i64, local_offset: UtcOffset) -> Option<OffsetDateTime> {
+    OffsetDateTime::from_unix_timestamp_nanos(i128::from(ms) * 1_000_000)
+        .ok()
+        .map(|time| time.to_offset(local_offset))
+}
+
+/// A protobuf `{#1: seconds, #2: nanos}` Timestamp → epoch milliseconds.
+fn proto_timestamp_ms(ts: &[u8]) -> Option<i64> {
+    let seconds = i64::try_from(varint_field(ts, 1)?).ok()?;
+    let nanos = i64::try_from(varint_field(ts, 2).unwrap_or(0)).ok()?;
+    seconds.checked_mul(1000)?.checked_add(nanos / 1_000_000)
+}
+
+// ── Minimal protobuf wire reader (no prost / schema) ───────────────────────
+
+enum Wire<'a> {
+    Varint(u64),
+    Len(&'a [u8]),
+}
+
+struct ProtoReader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> ProtoReader<'a> {
+    fn read_varint(&mut self) -> Option<u64> {
+        let mut result = 0u64;
+        let mut shift = 0u32;
+        loop {
+            let byte = *self.buf.get(self.pos)?;
+            self.pos += 1;
+            result |= u64::from(byte & 0x7f) << shift;
+            if byte & 0x80 == 0 {
+                return Some(result);
+            }
+            shift += 7;
+            if shift >= 64 {
+                return None;
+            }
+        }
+    }
+
+    fn next_field(&mut self) -> Option<(u64, Wire<'a>)> {
+        if self.pos >= self.buf.len() {
+            return None;
+        }
+        let tag = self.read_varint()?;
+        let wire = match tag & 0x7 {
+            0 => Wire::Varint(self.read_varint()?),
+            1 => {
+                self.pos = self.pos.checked_add(8).filter(|&p| p <= self.buf.len())?;
+                return Some((tag >> 3, Wire::Varint(0))); // fixed64, value unused
+            }
+            2 => {
+                let len = usize::try_from(self.read_varint()?).ok()?;
+                let end = self.pos.checked_add(len).filter(|&p| p <= self.buf.len())?;
+                let bytes = &self.buf[self.pos..end];
+                self.pos = end;
+                Wire::Len(bytes)
+            }
+            5 => {
+                self.pos = self.pos.checked_add(4).filter(|&p| p <= self.buf.len())?;
+                return Some((tag >> 3, Wire::Varint(0))); // fixed32, value unused
+            }
+            _ => return None,
+        };
+        Some((tag >> 3, wire))
+    }
+}
+
+fn message_field(buf: &[u8], field: u64) -> Option<&[u8]> {
+    let mut reader = ProtoReader { buf, pos: 0 };
+    while let Some((found, wire)) = reader.next_field() {
+        if found == field
+            && let Wire::Len(bytes) = wire
+        {
+            return Some(bytes);
+        }
+    }
+    None
+}
+
+fn varint_field(buf: &[u8], field: u64) -> Option<u64> {
+    let mut reader = ProtoReader { buf, pos: 0 };
+    while let Some((found, wire)) = reader.next_field() {
+        if found == field
+            && let Wire::Varint(value) = wire
+        {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn string_field(buf: &[u8], field: u64) -> Option<&str> {
+    message_field(buf, field).and_then(|bytes| std::str::from_utf8(bytes).ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn varint(field: u64, value: u64) -> Vec<u8> {
+        let mut out = enc(field << 3);
+        out.extend(enc(value));
+        out
+    }
+    fn lenf(field: u64, payload: &[u8]) -> Vec<u8> {
+        let mut out = enc((field << 3) | 2);
+        out.extend(enc(payload.len() as u64));
+        out.extend_from_slice(payload);
+        out
+    }
+    fn enc(mut v: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let mut b = (v & 0x7f) as u8;
+            v >>= 7;
+            if v != 0 {
+                b |= 0x80;
+            }
+            out.push(b);
+            if v == 0 {
+                break;
+            }
+        }
+        out
+    }
+
+    fn gen_blob(
+        system: u64,
+        input: u64,
+        cache: u64,
+        output: u64,
+        think: u64,
+        total: u64,
+    ) -> Vec<u8> {
+        let mut usage = Vec::new();
+        usage.extend(varint(1, system));
+        usage.extend(varint(2, input));
+        usage.extend(varint(3, total));
+        usage.extend(varint(5, cache));
+        usage.extend(varint(9, output));
+        usage.extend(varint(10, think));
+        usage.extend(lenf(11, b"resp-1"));
+        let mut chat = Vec::new();
+        chat.extend(lenf(4, &usage));
+        chat.extend(lenf(19, b"gemini-3-flash"));
+        lenf(1, &chat)
+    }
+
+    #[test]
+    fn maps_tokens_and_model() {
+        let blob = gen_blob(1132, 500, 16000, 300, 40, 340);
+        let ParseGen::Event(e) = parse_gen(
+            &blob,
+            "s1",
+            1_700_000_000_000,
+            Some("/x/proj"),
+            UtcOffset::UTC,
+        ) else {
+            panic!("expected event");
+        };
+        assert_eq!(e.usage.input_tokens, 1632); // 1132 + 500
+        assert_eq!(e.usage.cache_read_input_tokens, 16000);
+        assert_eq!(e.usage.output_tokens, 340); // 300 + 40 (thinking folded in)
+        assert_eq!(e.usage.reasoning_output_tokens, 40);
+        assert_eq!(e.model.as_deref(), Some("gemini-3-flash"));
+    }
+
+    #[test]
+    fn self_verify_rejects_drifted_total() {
+        // #3 (999) != #9 + #10 (300 + 40) → layout drift → Drift, not garbage.
+        let blob = gen_blob(1132, 500, 0, 300, 40, 999);
+        assert!(matches!(
+            parse_gen(&blob, "s1", 1, None, UtcOffset::UTC),
+            ParseGen::Drift
+        ));
+    }
+
+    #[test]
+    fn all_zero_is_empty() {
+        let blob = gen_blob(0, 0, 0, 0, 0, 0);
+        assert!(matches!(
+            parse_gen(&blob, "s1", 1, None, UtcOffset::UTC),
+            ParseGen::Empty
+        ));
+    }
+}

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -1,4 +1,5 @@
 pub mod agy;
+mod agy_conv;
 pub mod claude;
 pub mod codex;
 pub mod opencode;


### PR DESCRIPTION
## What

Antigravity was **activity-only** — its tab showed sessions/tools but no tokens, because its usage lives in an undocumented protobuf. It turns out the CLI's per-conversation SQLite (`~/.gemini/antigravity-cli/conversations/<uuid>.db`, table `gen_metadata`) holds it after all. This reads it, so Antigravity now contributes real **tokens, models, and projects** like the other providers.

## How

New `src/collector/agy_conv.rs` decodes the unlabeled `gen_metadata` protobuf with a tiny wire reader (no `prost`/schema), pulling by field number:

| field | meaning |
|---|---|
| `usage.#1 + #2` | input (fixed system prompt + new input) |
| `usage.#5` | cache-read |
| `usage.#9` | output (text) |
| `usage.#10` | thinking / reasoning |
| `chatModel.#19` | model id |
| `trajectory_metadata_blob.#1.#1` | project (workspace URI) |
| `chatModel.#9.#4` | per-generation timestamp |

The field numbers were reverse-engineered and **cross-checked against [tokscale](https://github.com/junhoyeo/tokscale)**, which maps them identically. Thinking is folded into output (same convention as OpenCode).

## Self-verification

Because the field numbers are unofficial and could shift on an Antigravity update, **every row is self-verified**: the stored output total (`#3`) must equal `#9 + #10`. A mismatch means the layout drifted → the row is skipped and counted as a parse error, never emitting garbage tokens. Untrusted varints are clamped to `i64` and combined with saturating arithmetic.

**Verified on real data: 52.7M tokens, 0 parse errors**, with per-model (gemini-3-flash, …) and per-project breakdowns.

## Notes

- The text-log pass stays for the activity/tool timeline but no longer emits zero-token model-attribution events (the real ones supersede them).
- **Cost shows $0** for Antigravity — its gemini model ids aren't matched to the pricing table yet, and the pricing path is currently `claude-*`/`gpt-*` only. Follow-up.
- Independent of the Cursor PR (#18); branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)