### PR TITLE
Scan Codex archived_sessions (fixes #19)

### DIFF
--- a/docs/codex.md
+++ b/docs/codex.md
@@ -2,7 +2,12 @@
 
 ## Where the data comes from
 
-`~/.codex/sessions/**/*.jsonl` — rollout session logs. Read-only.
+`~/.codex/sessions/**/*.jsonl` and `~/.codex/archived_sessions/**/*.jsonl` —
+rollout session logs. Read-only. The Codex desktop app *moves* (not copies) a
+session's JSONL from `sessions/` to `archived_sessions/` when it's archived, so
+both are scanned; a session that briefly exists in both (a stale copy) is
+deduplicated by relative path before parsing. `--codex-dir` overrides the
+**sessions** directory; its `archived_sessions` sibling is derived from it.
 
 ## What's captured
 

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -23,11 +23,22 @@ pub fn collect(
     local_offset: UtcOffset,
 ) -> Collection {
     let mut collection = Collection::new(Provider::Codex, root.to_path_buf());
-    if !root.exists() {
+
+    // Codex *moves* (not copies) a session's JSONL from `sessions/` to
+    // `archived_sessions/` when the desktop app archives it, so a sessions-only
+    // scan silently drops archived history. Scan the sibling `archived_sessions`
+    // too; a session that exists in both dirs dedupes via keyed events.
+    let archived = root.parent().map(|parent| parent.join("archived_sessions"));
+    let mut files = Vec::new();
+    for dir in std::iter::once(root).chain(archived.as_deref()) {
+        if dir.exists() {
+            files.extend(list_files(dir, "jsonl", mtime_floor, &mut collection.stats));
+        }
+    }
+    if files.is_empty() {
         return collection;
     }
 
-    let files = list_files(root, "jsonl", mtime_floor, &mut collection.stats);
     let per_file = parse_files_cached(use_cache.then_some("codex"), &files, local_offset, |path| {
         parse_file(path, local_offset)
     });
@@ -502,6 +513,74 @@ mod tests {
             .map(|event| event.usage.token_volume())
             .sum();
         assert_eq!(total, 220);
+    }
+
+    /// The Codex desktop app *moves* a session's JSONL from `sessions/` to the
+    /// sibling `archived_sessions/`, so the collector must scan both.
+    #[test]
+    fn scans_sibling_archived_sessions() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        let sessions_day = temp.path().join("sessions/2026/06/01");
+        let archived_day = temp.path().join("archived_sessions/2026/06/01");
+        fs::create_dir_all(&sessions_day).expect("test dirs should be created");
+        fs::create_dir_all(&archived_day).expect("test dirs should be created");
+        fs::write(
+            sessions_day.join("rollout-active.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1","model_provider":"openai"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":110}}}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+        fs::write(
+            archived_day.join("rollout-archived.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s2","model_provider":"openai"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":200,"cached_input_tokens":0,"output_tokens":20,"total_tokens":220}}}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(&temp.path().join("sessions"), None, false, UtcOffset::UTC);
+
+        // Both the active and the archived session are counted.
+        assert_eq!(collection.stats.files_seen, 2);
+        assert_eq!(collection.usage_events.len(), 2);
+        let total: u64 = collection
+            .usage_events
+            .iter()
+            .map(|event| event.usage.token_volume())
+            .sum();
+        assert_eq!(total, 330); // 110 (active) + 220 (archived)
+    }
+
+    /// A session present in *both* dirs (a stale `sessions/` copy left after an
+    /// archive) must not double-count — the keyed events dedupe it to one turn.
+    #[test]
+    fn dedups_session_present_in_sessions_and_archive() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        let sessions_day = temp.path().join("sessions/2026/06/01");
+        let archived_day = temp.path().join("archived_sessions/2026/06/01");
+        fs::create_dir_all(&sessions_day).expect("test dirs should be created");
+        fs::create_dir_all(&archived_day).expect("test dirs should be created");
+        let lines = concat!(
+            r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1","model_provider":"openai"}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":110}}}}"#,
+            "\n"
+        );
+        fs::write(sessions_day.join("rollout-s1.jsonl"), lines).expect("fixture should be written");
+        fs::write(archived_day.join("rollout-s1.jsonl"), lines).expect("fixture should be written");
+
+        let collection = collect(&temp.path().join("sessions"), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.stats.files_seen, 2); // both files read
+        assert_eq!(collection.usage_events.len(), 1); // deduped to one turn
+        assert_eq!(collection.usage_events[0].usage.token_volume(), 110);
     }
 
     /// Shell-wrapper tool calls (`exec_command` etc.) are decomposed to the real

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -1,6 +1,7 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use serde_json::Value;
@@ -24,20 +25,46 @@ pub fn collect(
 ) -> Collection {
     let mut collection = Collection::new(Provider::Codex, root.to_path_buf());
 
-    // Codex *moves* (not copies) a session's JSONL from `sessions/` to
-    // `archived_sessions/` when the desktop app archives it, so a sessions-only
-    // scan silently drops archived history. Scan the sibling `archived_sessions`
-    // too; a session that exists in both dirs dedupes via keyed events.
-    let archived = root.parent().map(|parent| parent.join("archived_sessions"));
-    let mut files = Vec::new();
+    // Codex *moves* (not copies) a session's JSONL from `sessions/` to the
+    // sibling `archived_sessions/` when the desktop app archives it, so a
+    // sessions-only scan silently drops archived history. Scan both. Resolve the
+    // sibling from the canonical path so a relative root (e.g. `.`) still finds
+    // `../archived_sessions`, falling back to the raw parent when the path can't
+    // be canonicalized (root missing).
+    let archived = root
+        .canonicalize()
+        .ok()
+        .as_deref()
+        .unwrap_or(root)
+        .parent()
+        .map(|parent| parent.join("archived_sessions"));
+
+    // A session can briefly exist in both dirs (a stale `sessions/` copy left
+    // after archiving). Dedupe by relative path before parsing — keeping the
+    // larger, more-complete file — so duration events and session touches (which
+    // merge_into does not key-dedupe) can't double-count.
+    let file_len = |path: &Path| std::fs::metadata(path).map(|meta| meta.len()).unwrap_or(0);
+    let mut chosen: HashMap<PathBuf, PathBuf> = HashMap::new();
     for dir in std::iter::once(root).chain(archived.as_deref()) {
-        if dir.exists() {
-            files.extend(list_files(dir, "jsonl", mtime_floor, &mut collection.stats));
+        if !dir.exists() {
+            continue;
+        }
+        for path in list_files(dir, "jsonl", mtime_floor, &mut collection.stats) {
+            let rel = path.strip_prefix(dir).unwrap_or(&path).to_path_buf();
+            match chosen.get_mut(&rel) {
+                Some(existing) if file_len(&path) > file_len(existing) => *existing = path,
+                Some(_) => {}
+                None => {
+                    chosen.insert(rel, path);
+                }
+            }
         }
     }
-    if files.is_empty() {
+    if chosen.is_empty() {
         return collection;
     }
+    let mut files: Vec<PathBuf> = chosen.into_values().collect();
+    files.sort();
 
     let per_file = parse_files_cached(use_cache.then_some("codex"), &files, local_offset, |path| {
         parse_file(path, local_offset)
@@ -578,9 +605,14 @@ mod tests {
 
         let collection = collect(&temp.path().join("sessions"), None, false, UtcOffset::UTC);
 
-        assert_eq!(collection.stats.files_seen, 2); // both files read
-        assert_eq!(collection.usage_events.len(), 1); // deduped to one turn
+        // The stale duplicate is filtered by relative path before parsing, so
+        // only one file is read. Its two timestamped lines yield two session
+        // touches — not four — proving the duplicate didn't double-count (the
+        // bug this guards: session_touches / duration_events aren't key-deduped).
+        assert_eq!(collection.stats.files_seen, 1);
+        assert_eq!(collection.usage_events.len(), 1);
         assert_eq!(collection.usage_events[0].usage.token_volume(), 110);
+        assert_eq!(collection.session_touches.len(), 2);
     }
 
     /// Shell-wrapper tool calls (`exec_command` etc.) are decomposed to the real


### PR DESCRIPTION
## Problem (#19)

When the Codex desktop app archives a session, it **moves** (not copies) the JSONL from `~/.codex/sessions/` to the sibling `~/.codex/archived_sessions/`. agent-walker only read `sessions/`, so archived sessions silently dropped out of the totals — a reporter saw the Codex tab show 117.5M tokens vs ~478M actual.

## Fix

- The Codex collector now scans `archived_sessions/` in addition to `sessions/`. The sibling is derived from the canonical sessions root, so it also works under `CODEX_HOME` / `--codex-dir` (and a relative root like `.`).
- A session can briefly exist in both dirs (a stale `sessions/` copy left after archiving). `merge_into` only key-dedupes usage/tool events — `session_touches` and `duration_events` are appended without a key, so a duplicate would double-count session and duration stats. Fixed by **deduplicating files by relative path before parsing** (keeping the larger, more-complete file), so the same session is never parsed twice.

## Verification

- New unit tests: `scans_sibling_archived_sessions` (a distinct active + archived session are both counted) and `dedups_session_present_in_sessions_and_archive` (a session in both dirs is read once — its two timestamped lines yield two touches, not four, proving no double-counting).
- 92 tests pass, clippy/fmt clean.
- Reviewed by gemini (HIGH: the touches/duration double-count, fixed) and Codex (CLI + bot: no core-logic blockers; only low-risk doc follow-ups, applied to docs/codex.md).

Fixes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)