### PR TITLE
Harden Cursor egress, sanitize card labels, honest Antigravity invariant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an artifact meant to carry none.
 - `SECURITY.md` now documents the Cursor session-cookie egress and lists every
   provider read; `docs/agy.md` states honestly what the Antigravity per-row
-  output-total check does (catches field renumbering) and doesn't (an input-field
-  re-meaning with no wire change) guarantee.
+  output-total check does (catches a re-meaning of the output tags `#3`/`#9`/
+  `#10`) and doesn't (a re-meaning of the input tags) guarantee.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `--no-cursor` disables the Cursor collector — the only one that reaches the
+  network — keeping agent-walker fully offline.
+
+### Changed
+
+- Model labels are sanitized (printable set, length-capped, no path separators or
+  control characters) before they can reach the shareable card / clipboard, so a
+  crafted log can't smuggle a repo name, absolute path, or token-like string onto
+  an artifact meant to carry none.
+- `SECURITY.md` now documents the Cursor session-cookie egress and lists every
+  provider read; `docs/agy.md` states honestly what the Antigravity per-row
+  output-total check does (catches field renumbering) and doesn't (an input-field
+  re-meaning with no wire change) guarantee.
+
+### Fixed
+
+- The Cursor usage fetch no longer follows redirects, so the session cookie can
+  only ever reach `cursor.com` and never a redirect target. Tokens with ASCII
+  control characters are rejected (header-injection guard), and `CursorConfig`'s
+  `Debug` redacts the token so it can't leak into a log or panic message.
+- A present-but-unparseable Cursor token cell (e.g. a thousands-separated
+  `1,234` after a format change) now drops the row as a parse error instead of
+  silently recording 0 tokens — degrade to less data, never a wrong number.
+
 ## [0.6.0] - 2026-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `--no-cursor` disables the Cursor collector — the only one that reaches the
-  network — keeping agent-walker fully offline.
+- `--no-cursor` disables the Cursor collector — the only collector that sends a
+  credential off the machine — stopping that egress. (The anonymous LiteLLM
+  pricing fetch still runs.)
 
 ### Changed
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -60,7 +60,9 @@ bunx agent-walker
 | `--days <N>` | グラフの集計期間（既定 30。codename のトークン量レベルは常に直近 30 日からとるので、`--days` を変えても rank はぶれない） |
 | `--share <path>` | カードを PNG 出力＋キャプション表示して終了 |
 | `--no-cache` | パースキャッシュを無視して全再走査 |
+| `--no-cursor` | Cursor コレクタを無効化。Cursor はマシン外に資格情報（Cursor のセッション cookie を cursor.com へ）を送る唯一のコレクタなので、これを付けるとネットワークリクエストを一切行わない |
 | `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` | 非標準のログ場所を指定（`CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `OPENCODE_HOME` も自動で読む） |
+| `--cursor-state-db` | 非標準の Cursor `state.vscdb` を指定（または `CURSOR_TOKEN` でセッショントークンを直接渡す） |
 | `--completions <shell>` | シェル補完を出力して終了 |
 
 ## codename を共有

--- a/README.md
+++ b/README.md
@@ -143,11 +143,11 @@ indefinitely; no setting needed.
   users the bulk of the total tends to be cache reads — real but cheaply
   billed context re-reads, not new work. See [docs/claude.md](docs/claude.md).
 - **Antigravity tokens are read from an undocumented protobuf** (its
-  per-conversation SQLite), decoded by field number and checked per row against
-  the stored output total (which catches field renumbering, the likely drift; the
-  residual gap is noted in [docs/agy.md](docs/agy.md)), so they count toward the
-  totals. Cost is estimated from its Gemini model's display name via the same
-  LiteLLM table as every other agent.
+  per-conversation SQLite), decoded by tag number and checked per row for mutual
+  consistency of the output fields (`#3 == #9 + #10`), which catches a re-meaning
+  of those output tags; the residual gap is noted in [docs/agy.md](docs/agy.md).
+  They count toward the totals. Cost is estimated from its Gemini model's display
+  name via the same LiteLLM table as every other agent.
 - These numbers **won't match each agent's own in-app usage display**: those use
   different time windows and count cache reads differently. See the per-agent
   pages above.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ Flags:
 | `--days <N>` | Analysis window for the graphs (default 30; the codename's throughput level is always taken from the last 30 days, so the rank doesn't drift with `--days`) |
 | `--share <path>` | Render the stats card to a PNG, print its caption, and exit |
 | `--no-cache` | Rescan every log file, ignoring the parse cache |
+| `--no-cursor` | Disable the Cursor collector — the only one that sends a credential off the machine (your Cursor session cookie, to cursor.com) — so it makes no network request |
 | `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` | Point at non-standard log locations (also honors `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, and `OPENCODE_HOME` when set) |
+| `--cursor-state-db` | Point at a non-standard Cursor `state.vscdb` (or set `CURSOR_TOKEN` to supply the session token directly) |
 | `--completions <shell>` | Print shell completions (e.g. `--completions zsh`) and exit |
 
 ## Share your codename

--- a/README.md
+++ b/README.md
@@ -143,10 +143,11 @@ indefinitely; no setting needed.
   users the bulk of the total tends to be cache reads — real but cheaply
   billed context re-reads, not new work. See [docs/claude.md](docs/claude.md).
 - **Antigravity tokens are read from an undocumented protobuf** (its
-  per-conversation SQLite), decoded by field number and self-verified per row, so
-  they count toward the totals. Cost is estimated from its Gemini model's
-  display name via the same LiteLLM table as every other agent; see
-  [docs/agy.md](docs/agy.md).
+  per-conversation SQLite), decoded by field number and checked per row against
+  the stored output total (which catches field renumbering, the likely drift; the
+  residual gap is noted in [docs/agy.md](docs/agy.md)), so they count toward the
+  totals. Cost is estimated from its Gemini model's display name via the same
+  LiteLLM table as every other agent.
 - These numbers **won't match each agent's own in-app usage display**: those use
   different time windows and count cache reads differently. See the per-agent
   pages above.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,13 +10,25 @@ You can expect an initial response within a week.
 
 ## Scope notes
 
-agent-walker reads local log files written by AI coding agents
-(Claude Code, Codex CLI, Antigravity CLI) and renders aggregate statistics.
+agent-walker reads local log/usage stores written by AI coding agents
+(Claude Code, Codex CLI, Antigravity CLI, OpenCode, Cursor) and renders
+aggregate statistics.
 
-- The only network access is a per-run fetch of public model-pricing metadata
-  from [LiteLLM's pricing database](https://github.com/BerriAI/litellm).
-  No usage data, log content, or telemetry is ever transmitted.
-- Log lines are treated as untrusted input: malformed JSON is counted and
-  skipped, never executed or evaluated.
+- **Network access.** Two kinds, both to read your own data — never any
+  telemetry, log content, or usage upload:
+  1. A per-run fetch of public model-pricing metadata from
+     [LiteLLM's pricing database](https://github.com/BerriAI/litellm).
+  2. **Cursor only:** Cursor keeps no usage on disk, so when you're signed in,
+     agent-walker reads your local Cursor session cookie and sends it to
+     `cursor.com` to fetch *your own* usage figures — the same request the
+     dashboard makes. This is the one collector that transmits a credential off
+     the machine. It is skipped when you're signed out, and `--no-cursor`
+     disables it entirely (keeping agent-walker fully offline). The cookie goes
+     only to `cursor.com` (redirects are not followed) and is never written to
+     disk, logs, or the shareable card.
+- Log lines and usage records are treated as untrusted input: malformed data is
+  counted and skipped, never executed or evaluated. Numeric aggregation uses
+  saturating arithmetic, and model labels are sanitized before they can reach the
+  shareable card.
 - Release binaries carry GitHub Artifact Attestations (SLSA build provenance);
   verify with `gh attestation verify <file> -R miiiiiiich/agent-walker`.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,7 +23,8 @@ aggregate statistics.
      `cursor.com` to fetch *your own* usage figures — the same request the
      dashboard makes. This is the one collector that transmits a credential off
      the machine. It is skipped when you're signed out, and `--no-cursor`
-     disables it entirely (keeping agent-walker fully offline). The cookie goes
+     disables it entirely — stopping the only egress that carries a credential
+     (the anonymous LiteLLM pricing fetch above still runs). The cookie goes
      only to `cursor.com` (redirects are not followed) and is never written to
      disk, logs, or the shareable card.
 - Log lines and usage records are treated as untrusted input: malformed data is

--- a/docs/agy.md
+++ b/docs/agy.md
@@ -26,11 +26,26 @@
 and there's no public schema. agent-walker reads the wire format directly and
 pulls the few fields it needs by number (cross-checked against the `tokscale`
 project, which maps them identically). Because the numbers are unofficial and
-could shift on an Antigravity update, **every row is self-verified**: the stored
-output total must equal text + thinking. A row that fails is skipped and counted
-as a parse error rather than contributing garbage tokens — so a future format
-change degrades to "no/less data," never to wrong numbers. See
-`src/collector/agy_conv.rs`.
+could shift on an Antigravity update, **every row is checked against the stored
+output total** (`#3`): it must equal text + thinking (`#9` + `#10`). A row that
+fails is skipped and counted as a parse error rather than contributing garbage
+tokens.
+
+What that check does and doesn't guarantee, stated honestly:
+
+- It catches **field renumbering** — the most likely kind of format drift.
+  Inserting or removing a field anywhere ahead of the output fields shifts what
+  `#9`/`#10` decode to, so the `#3 == #9 + #10` equality breaks and the row is
+  dropped.
+- It does **not** independently verify the input-side fields (system `#1`, new
+  input `#2`, cache read `#5`): there's no stored input total to check them
+  against. A pure *semantic* redefinition of those fields that left the wire
+  layout untouched would pass the output check and isn't detectable by any
+  checksum. That case has never been observed, but it's the residual risk.
+
+So a typical format change degrades to "no/less data"; the one gap is a silent
+input-field re-meaning, which we accept because no row-level invariant can catch
+it. See `src/collector/agy_conv.rs`.
 
 ## Cost
 

--- a/docs/agy.md
+++ b/docs/agy.md
@@ -31,21 +31,25 @@ output total** (`#3`): it must equal text + thinking (`#9` + `#10`). A row that
 fails is skipped and counted as a parse error rather than contributing garbage
 tokens.
 
-What that check does and doesn't guarantee, stated honestly:
+What that check does and doesn't guarantee, stated honestly. Protobuf
+identifies fields by an explicit tag number on the wire, not by position, so
+adding or removing *unrelated* fields doesn't change what `#9`/`#10` decode to —
+the decoder simply skips tags it doesn't read. The `#3 == #9 + #10` check is
+therefore not a positional guard; it's a **mutual-consistency** check on the
+three output fields:
 
-- It catches **field renumbering** — the most likely kind of format drift.
-  Inserting or removing a field anywhere ahead of the output fields shifts what
-  `#9`/`#10` decode to, so the `#3 == #9 + #10` equality breaks and the row is
-  dropped.
-- It does **not** independently verify the input-side fields (system `#1`, new
-  input `#2`, cache read `#5`): there's no stored input total to check them
-  against. A pure *semantic* redefinition of those fields that left the wire
-  layout untouched would pass the output check and isn't detectable by any
-  checksum. That case has never been observed, but it's the residual risk.
+- It catches a **re-meaning of the output fields**: if Antigravity reassigns the
+  output total (`#3`) or its parts (`#9` text, `#10` thinking) to different tag
+  numbers, our reads stop agreeing, the equality breaks, and the row is dropped.
+- It does **not** verify the input-side fields (system `#1`, new input `#2`,
+  cache read `#5`): there's no stored input total to check them against, so a
+  reassignment of those tags would be read as wrong numbers and pass the output
+  check undetected. That has never been observed, but it's the residual risk.
 
-So a typical format change degrades to "no/less data"; the one gap is a silent
-input-field re-meaning, which we accept because no row-level invariant can catch
-it. See `src/collector/agy_conv.rs`.
+So a re-meaning of the *output* fields degrades to "no/less data"; the gap is a
+silent re-meaning of an *input* field, which no row-level invariant can catch
+without an input checksum the format doesn't provide. See
+`src/collector/agy_conv.rs`.
 
 ## Cost
 

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -27,8 +27,10 @@ The cookie is `<accountId>::<jwt>`:
   a malformed JWT.
 
 `CURSOR_TOKEN` supplies the JWT directly (skip the local DB) and
-`--cursor-state-db` points at a non-standard `state.vscdb`. There's no flag to
-turn Cursor on or off — sign out of Cursor if you don't want it read.
+`--cursor-state-db` points at a non-standard `state.vscdb`. To stop the request
+entirely, pass `--no-cursor` (or sign out of Cursor) — Cursor is the only
+collector that sends a credential off the machine, so this is the one network
+egress you may want to disable.
 
 This endpoint is **undocumented** and can change or break without notice. A
 `401`/`403` means the session expired — re-login in Cursor to refresh the token,

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,9 +52,11 @@ pub struct Args {
     #[arg(long, value_name = "PATH")]
     pub cursor_state_db: Option<PathBuf>,
 
-    /// Disable the Cursor collector. Cursor is the only provider that reaches the
-    /// network — it sends your local Cursor session cookie to cursor.com to read
-    /// your own usage. Pass this to keep agent-walker fully offline.
+    /// Disable the Cursor collector. Cursor is the only collector that sends a
+    /// credential off the machine — your local Cursor session cookie, to
+    /// cursor.com, to read your own usage. Pass this to stop that egress.
+    /// (Anonymous model-pricing metadata is still fetched; it carries no
+    /// credential.)
     #[arg(long)]
     pub no_cursor: bool,
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -52,6 +52,12 @@ pub struct Args {
     #[arg(long, value_name = "PATH")]
     pub cursor_state_db: Option<PathBuf>,
 
+    /// Disable the Cursor collector. Cursor is the only provider that reaches the
+    /// network — it sends your local Cursor session cookie to cursor.com to read
+    /// your own usage. Pass this to keep agent-walker fully offline.
+    #[arg(long)]
+    pub no_cursor: bool,
+
     /// Analysis window. Defaults to 30 days — Claude Code retains roughly a
     /// month of logs. The codename level is always computed from the most recent
     /// 30 days, so changing this only resizes the graphs, never the title.
@@ -115,12 +121,24 @@ pub struct Config {
 }
 
 /// Resolved Cursor settings (see `Config::cursor`).
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CursorConfig {
     pub state_db: PathBuf,
     pub cli_config: PathBuf,
     /// Token override from `CURSOR_TOKEN`; `None` reads the local `state.vscdb`.
     pub token: Option<String>,
+}
+
+// Manual `Debug` so the session token never lands in a `{config:?}` dump (a log
+// line, stderr, a panic message). Only the presence of a token is shown.
+impl std::fmt::Debug for CursorConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CursorConfig")
+            .field("state_db", &self.state_db)
+            .field("cli_config", &self.cli_config)
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .finish()
+    }
 }
 
 pub fn run(args: Args) -> Result<()> {
@@ -264,8 +282,9 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
                     config.local_offset,
                 )
             });
-            // Cursor is opt-in and the only collector that hits the network, so
-            // it runs in its own thread alongside the local ones.
+            // Cursor is auto-detected (disable with --no-cursor) and the only
+            // collector that hits the network, so it runs in its own thread
+            // alongside the local ones.
             let cursor_handle = scope.spawn(|| {
                 config.cursor.as_ref().map(|cursor| {
                     cursor::collect(
@@ -358,13 +377,19 @@ fn default_opencode_dir() -> Result<PathBuf> {
 }
 
 /// Build the Cursor config. Cursor is **auto-detected** like the other providers
-/// (no flag to turn it on or off): it runs whenever there's something to read —
-/// an explicit `CURSOR_TOKEN`, or a local `state.vscdb` that exists. With
-/// neither there's nothing to detect, so it's skipped. Signed out (store exists
-/// but no token) it stays silent and never hits the network — handled in the
-/// collector. Path resolution failures fall back to empty paths so an explicit
-/// token still works in CI / sandboxes where the home dir can't be resolved.
+/// — it runs whenever there's something to read (an explicit `CURSOR_TOKEN`, or a
+/// local `state.vscdb` that exists) — but because it's the one collector that
+/// reaches the network, `--no-cursor` turns it off entirely. With nothing to
+/// detect it's skipped. Signed out (store exists but no token) it stays silent
+/// and never hits the network — handled in the collector. Path resolution
+/// failures fall back to empty paths so an explicit token still works in CI /
+/// sandboxes where the home dir can't be resolved.
 fn cursor_config(args: &Args) -> Option<CursorConfig> {
+    // The one network-reaching collector is opt-out: honor --no-cursor before
+    // touching the env or disk so nothing is read and no request is made.
+    if args.no_cursor {
+        return None;
+    }
     let token = env::var("CURSOR_TOKEN")
         .ok()
         .filter(|token| !token.trim().is_empty());

--- a/src/collector/cursor.rs
+++ b/src/collector/cursor.rs
@@ -55,7 +55,14 @@ pub fn collect(
     let mut collection = Collection::new(Provider::Cursor, state_db.to_path_buf());
 
     let jwt = if let Some(token) = token_override {
-        token.trim().to_owned()
+        // An explicit CURSOR_TOKEN that's too short or carries control
+        // characters is unusable — a real failure, not signed-out.
+        if let Some(token) = sanitize_token(token) {
+            token
+        } else {
+            collection.stats.unreadable_files += 1;
+            return collection;
+        }
     } else {
         match read_access_token(state_db) {
             Ok(Some(token)) => token,
@@ -115,16 +122,24 @@ fn read_access_token(state_db: &Path) -> Result<Option<String>, ()> {
         Connection::open_with_flags(state_db, OpenFlags::SQLITE_OPEN_READ_ONLY).map_err(|_| ())?;
     let _ = conn.busy_timeout(Duration::from_millis(500));
     match conn.query_row(ACCESS_TOKEN_SQL, [], |row| row.get::<_, String>(0)) {
-        Ok(token) => {
-            // Cursor stores this token raw, but other VS Code `ItemTable` values
-            // are JSON-serialized strings; strip surrounding quotes defensively
-            // (a JWT never contains `"`, so this is a no-op on the raw form).
-            let token = token.trim().trim_matches('"');
-            Ok((token.len() >= 10).then(|| token.to_owned()))
-        }
+        // A present row that doesn't sanitize to a usable token (too short, or
+        // control characters) reads as `None` — effectively signed out — rather
+        // than a hard error.
+        Ok(token) => Ok(sanitize_token(&token)),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
         Err(_) => Err(()),
     }
+}
+
+/// A usable session token. Cursor stores the JWT raw, but other VS Code
+/// `ItemTable` values are JSON-serialized strings, so surrounding quotes are
+/// stripped defensively (a JWT never contains `"`). The token must be long
+/// enough to be a JWT and free of ASCII control characters — a CR/LF would let a
+/// crafted store or a malformed `CURSOR_TOKEN` inject extra `Cookie` headers.
+fn sanitize_token(raw: &str) -> Option<String> {
+    let token = raw.trim().trim_matches('"').trim();
+    (token.len() >= 10 && token.bytes().all(|byte| !byte.is_ascii_control()))
+        .then(|| token.to_owned())
 }
 
 /// The account id for the cookie. The JWT `sub` is authoritative — it's the
@@ -183,7 +198,13 @@ fn normalize_subject(subject: &str) -> Option<String> {
 /// short reason for the log: a 401/403 means the session expired (re-login in
 /// Cursor), other statuses and transport failures pass their own message.
 fn fetch_csv(cookie: &str) -> Result<String, String> {
-    let response = ureq::get(CSV_URL)
+    // Don't follow redirects: the session cookie is attached by hand, so a 3xx
+    // from the endpoint must never carry it to another host. With redirects
+    // disabled the cookie only ever reaches cursor.com; a redirect is refused
+    // below rather than chased.
+    let agent = ureq::builder().redirects(0).build();
+    let response = agent
+        .get(CSV_URL)
         // The fetch is synchronous and the dashboard waits on it, so keep the
         // cap short — the CSV is tiny; a slow network shouldn't hang startup.
         .timeout(Duration::from_secs(5))
@@ -199,6 +220,14 @@ fn fetch_csv(cookie: &str) -> Result<String, String> {
             ureq::Error::Status(code, _) => format!("HTTP {code} from the usage endpoint"),
             ureq::Error::Transport(transport) => format!("network error: {transport}"),
         })?;
+    // With redirects disabled a 3xx returns as `Ok`; refuse it instead of
+    // reading a redirect target's body (the cookie was never sent there).
+    let status = response.status();
+    if (300..400).contains(&status) {
+        return Err(format!(
+            "unexpected redirect (HTTP {status}) from the usage endpoint"
+        ));
+    }
     response
         .into_string()
         .map_err(|err| format!("reading the response body: {err}"))
@@ -267,11 +296,29 @@ fn parse_csv(
         // `Input (w/o Cache Write)` + `Input (w/ Cache Write)` + `Cache Read` +
         // `Output Tokens`. So `Input (w/ Cache Write)` *is* the cache-write count
         // (default 0 if the column is absent), not a superset to subtract from.
+        //
+        // Required token cells parse strictly: an empty cell is a legitimate 0,
+        // but a present-but-unparseable value (e.g. a thousands-separated
+        // "1,234" after a format change) drops the whole row rather than
+        // silently recording 0 tokens — degrade to less data, never a wrong one.
+        let cache_creation = match input_with_idx {
+            Some(idx) => parse_required(cell(idx)),
+            None => Some(0),
+        };
+        let (Some(input_tokens), Some(output_tokens), Some(cache_read), Some(cache_creation)) = (
+            parse_required(cell(input_idx)),
+            parse_required(cell(output_idx)),
+            parse_required(cell(cache_read_idx)),
+            cache_creation,
+        ) else {
+            collection.stats.parse_errors += 1;
+            continue;
+        };
         let usage = TokenUsage {
-            input_tokens: parse_u64(cell(input_idx)),
-            output_tokens: parse_u64(cell(output_idx)),
-            cache_creation_input_tokens: input_with_idx.map_or(0, |idx| parse_u64(cell(idx))),
-            cache_read_input_tokens: parse_u64(cell(cache_read_idx)),
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens: cache_creation,
+            cache_read_input_tokens: cache_read,
             ..TokenUsage::default()
         };
 
@@ -318,9 +365,21 @@ fn parse_csv(
 }
 
 /// Parse an unsigned count from a possibly-quoted CSV cell; anything malformed
-/// is treated as zero rather than aborting the row.
+/// is treated as zero rather than aborting the row. Used for the `Total Tokens`
+/// checksum, which is advisory — a bad value there shouldn't drop the row.
 fn parse_u64(cell: &str) -> u64 {
     cell.trim().parse::<u64>().unwrap_or(0)
+}
+
+/// Parse a *required* token cell. An empty cell is a legitimate 0; a
+/// present-but-unparseable value returns `None` so the caller drops the row
+/// instead of recording a wrong 0.
+fn parse_required(cell: &str) -> Option<u64> {
+    let cell = cell.trim();
+    if cell.is_empty() {
+        return Some(0);
+    }
+    cell.parse::<u64>().ok()
 }
 
 /// Split one CSV record, honoring `"`-quoted fields with embedded commas and
@@ -422,6 +481,40 @@ mod tests {
         let collection = parse(csv, None);
         assert_eq!(collection.usage_events.len(), 1);
         assert_eq!(collection.stats.parse_errors, 1);
+    }
+
+    #[test]
+    fn unparseable_token_cell_drops_row_not_records_zero() {
+        // A thousands-separated "1,234" (a plausible format change) is NOT a 0 —
+        // the row is dropped and counted as a parse error rather than silently
+        // recording wrong token counts.
+        let csv = "Date,Model,Input (w/o Cache Write),Cache Read,Output Tokens\n\
+            \"2026-06-22T13:09:44Z\",\"m\",\"1,234\",\"0\",\"5\"\n";
+        let collection = parse(csv, None);
+        assert!(collection.usage_events.is_empty());
+        assert_eq!(collection.stats.parse_errors, 1);
+    }
+
+    #[test]
+    fn empty_token_cell_is_zero_not_a_drop() {
+        // An absent value is a legitimate 0; the row is still recorded.
+        let csv = "Date,Model,Input (w/o Cache Write),Cache Read,Output Tokens\n\
+            \"2026-06-22T13:09:44Z\",\"m\",\"\",\"0\",\"5\"\n";
+        let event = &parse(csv, None).usage_events[0];
+        assert_eq!(event.usage.input_tokens, 0);
+        assert_eq!(event.usage.output_tokens, 5);
+    }
+
+    #[test]
+    fn control_chars_in_token_are_rejected() {
+        // A CR/LF in the stored token would let a crafted store inject extra
+        // Cookie headers; sanitize_token refuses it.
+        assert!(sanitize_token("abcdefghij\r\nInjected: 1").is_none());
+        assert!(sanitize_token("short").is_none());
+        assert_eq!(
+            sanitize_token("  \"abcdefghij\"  ").as_deref(),
+            Some("abcdefghij")
+        );
     }
 
     #[test]

--- a/src/collector/cursor.rs
+++ b/src/collector/cursor.rs
@@ -188,13 +188,29 @@ fn normalize_subject(subject: &str) -> Option<String> {
     {
         return Some(tail.to_owned());
     }
-    // Otherwise accept any single-pipe `<provider>|<id>` with non-empty halves.
+    // Otherwise accept any single-pipe `<provider>|<id>` with non-empty halves —
+    // but only when both halves are safe id characters. This subject is decoded
+    // from the JWT payload (arbitrary bytes once base64-decoded), and unlike the
+    // raw token it is NOT constrained to base64url, so a `sub` carrying a CR/LF
+    // or a cookie metacharacter would otherwise be interpolated straight into
+    // the `Cookie` header. Validating here is what makes the token's
+    // header-injection guard hold for the bridged-OAuth path too.
     match subject.split_once('|') {
-        Some((provider, id)) if !provider.is_empty() && !id.is_empty() && !id.contains('|') => {
+        Some((provider, id)) if is_safe_subject_part(provider) && is_safe_subject_part(id) => {
             Some(subject.to_owned())
         }
         _ => None,
     }
+}
+
+/// A non-empty `<provider>` / `<id>` half of a bridged-OAuth subject, restricted
+/// to characters safe to interpolate into a cookie value (no CR/LF, no `;`/`=`/
+/// `,`/space, no second `|`).
+fn is_safe_subject_part(part: &str) -> bool {
+    !part.is_empty()
+        && part
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
 /// `GET` the usage CSV with the browser-equivalent headers. The `Err` carries a
@@ -571,5 +587,14 @@ mod tests {
         );
         assert_eq!(normalize_subject("weird-value"), None);
         assert_eq!(normalize_subject("a|b|c"), None);
+    }
+
+    #[test]
+    fn bridged_subject_with_unsafe_chars_is_rejected() {
+        // The subject is decoded from the JWT payload, so a `sub` carrying a
+        // CR/LF or a cookie metacharacter must not reach the Cookie header.
+        assert_eq!(normalize_subject("google-oauth2|123\r\nInjected: 1"), None);
+        assert_eq!(normalize_subject("google-oauth2|123; evil=1"), None);
+        assert_eq!(normalize_subject("prov ider|123"), None);
     }
 }

--- a/src/collector/cursor.rs
+++ b/src/collector/cursor.rs
@@ -133,13 +133,16 @@ fn read_access_token(state_db: &Path) -> Result<Option<String>, ()> {
 
 /// A usable session token. Cursor stores the JWT raw, but other VS Code
 /// `ItemTable` values are JSON-serialized strings, so surrounding quotes are
-/// stripped defensively (a JWT never contains `"`). The token must be long
-/// enough to be a JWT and free of ASCII control characters — a CR/LF would let a
-/// crafted store or a malformed `CURSOR_TOKEN` inject extra `Cookie` headers.
+/// stripped defensively (a JWT never contains `"`). A `WorkOS` session token is a
+/// JWT — `header.payload.signature`, each segment base64url (`[A-Za-z0-9_-]`)
+/// joined by `.` — so the token is restricted to exactly that character set.
+/// That rejects not just CR/LF (header injection) but every cookie
+/// metacharacter (`;`, `=`, `,`, space) that could split or confuse the `Cookie`
+/// header. A token that doesn't fit is treated as unusable rather than sent.
 fn sanitize_token(raw: &str) -> Option<String> {
     let token = raw.trim().trim_matches('"').trim();
-    (token.len() >= 10 && token.bytes().all(|byte| !byte.is_ascii_control()))
-        .then(|| token.to_owned())
+    let is_jwt_byte = |byte: u8| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.');
+    (token.len() >= 10 && token.bytes().all(is_jwt_byte)).then(|| token.to_owned())
 }
 
 /// The account id for the cookie. The JWT `sub` is authoritative — it's the
@@ -506,15 +509,23 @@ mod tests {
     }
 
     #[test]
-    fn control_chars_in_token_are_rejected() {
-        // A CR/LF in the stored token would let a crafted store inject extra
-        // Cookie headers; sanitize_token refuses it.
-        assert!(sanitize_token("abcdefghij\r\nInjected: 1").is_none());
-        assert!(sanitize_token("short").is_none());
+    fn only_jwt_chars_in_token_are_accepted() {
+        // A real JWT (base64url segments joined by '.') is accepted.
+        assert_eq!(
+            sanitize_token("eyJhbGci.eyJzdWIi.sig-na_ture").as_deref(),
+            Some("eyJhbGci.eyJzdWIi.sig-na_ture")
+        );
+        // Surrounding quotes / whitespace are stripped.
         assert_eq!(
             sanitize_token("  \"abcdefghij\"  ").as_deref(),
             Some("abcdefghij")
         );
+        // A CR/LF would inject extra Cookie headers; a ';'/'='/space could split
+        // or confuse the cookie — all rejected by the JWT-charset allowlist.
+        assert!(sanitize_token("abcdefghij\r\nInjected: 1").is_none());
+        assert!(sanitize_token("abcdefghij; evil=1").is_none());
+        assert!(sanitize_token("abcdefghij=padding").is_none());
+        assert!(sanitize_token("short").is_none());
     }
 
     #[test]

--- a/src/collector/cursor.rs
+++ b/src/collector/cursor.rs
@@ -204,13 +204,16 @@ fn normalize_subject(subject: &str) -> Option<String> {
 }
 
 /// A non-empty `<provider>` / `<id>` half of a bridged-OAuth subject, restricted
-/// to characters safe to interpolate into a cookie value (no CR/LF, no `;`/`=`/
-/// `,`/space, no second `|`).
+/// to characters safe to interpolate into a cookie value: no CR/LF, and none of
+/// the cookie metacharacters (`;`, `=`, `,`, space, `|`) that could split or
+/// confuse the header. `@` is allowed — it's a valid RFC 6265 cookie-octet and
+/// appears in email-based `sub` claims from enterprise OIDC / SAML providers, so
+/// rejecting it would silently lock out those accounts.
 fn is_safe_subject_part(part: &str) -> bool {
     !part.is_empty()
         && part
             .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'@'))
 }
 
 /// `GET` the usage CSV with the browser-equivalent headers. The `Err` carries a
@@ -311,34 +314,15 @@ fn parse_csv(
             continue;
         }
 
-        // The two input columns are disjoint, not nested: `Total Tokens` is
-        // `Input (w/o Cache Write)` + `Input (w/ Cache Write)` + `Cache Read` +
-        // `Output Tokens`. So `Input (w/ Cache Write)` *is* the cache-write count
-        // (default 0 if the column is absent), not a superset to subtract from.
-        //
-        // Required token cells parse strictly: an empty cell is a legitimate 0,
-        // but a present-but-unparseable value (e.g. a thousands-separated
-        // "1,234" after a format change) drops the whole row rather than
-        // silently recording 0 tokens — degrade to less data, never a wrong one.
-        let cache_creation = match input_with_idx {
-            Some(idx) => parse_required(cell(idx)),
-            None => Some(0),
-        };
-        let (Some(input_tokens), Some(output_tokens), Some(cache_read), Some(cache_creation)) = (
-            parse_required(cell(input_idx)),
-            parse_required(cell(output_idx)),
-            parse_required(cell(cache_read_idx)),
-            cache_creation,
+        let Some(usage) = row_usage(
+            &fields,
+            input_idx,
+            output_idx,
+            cache_read_idx,
+            input_with_idx,
         ) else {
             collection.stats.parse_errors += 1;
             continue;
-        };
-        let usage = TokenUsage {
-            input_tokens,
-            output_tokens,
-            cache_creation_input_tokens: cache_creation,
-            cache_read_input_tokens: cache_read,
-            ..TokenUsage::default()
         };
 
         // The CSV's own `Total Tokens` is a checksum; a mismatch is a soft
@@ -399,6 +383,49 @@ fn parse_required(cell: &str) -> Option<u64> {
         return Some(0);
     }
     cell.parse::<u64>().ok()
+}
+
+/// Token counts for one row, or `None` (a parse error) if the row is too short
+/// to reach the token columns or a required cell is present-but-unparseable.
+///
+/// The two input columns are disjoint, not nested: `Total Tokens` is
+/// `Input (w/o Cache Write)` + `Input (w/ Cache Write)` + `Cache Read` +
+/// `Output Tokens`, so `Input (w/ Cache Write)` *is* the cache-write count
+/// (default 0 if the column is absent), not a superset to subtract from.
+fn row_usage(
+    fields: &[String],
+    input_idx: usize,
+    output_idx: usize,
+    cache_read_idx: usize,
+    input_with_idx: Option<usize>,
+) -> Option<TokenUsage> {
+    // A row truncated before the token columns would read its missing cells as
+    // "" and parse to 0; require the row to actually reach every required column
+    // so a short row is a parse error, not a silent zero.
+    let required_max = [
+        Some(input_idx),
+        Some(output_idx),
+        Some(cache_read_idx),
+        input_with_idx,
+    ]
+    .into_iter()
+    .flatten()
+    .max()
+    .unwrap_or(0);
+    if fields.len() <= required_max {
+        return None;
+    }
+    let cell = |idx: usize| fields.get(idx).map_or("", String::as_str);
+    Some(TokenUsage {
+        input_tokens: parse_required(cell(input_idx))?,
+        output_tokens: parse_required(cell(output_idx))?,
+        cache_read_input_tokens: parse_required(cell(cache_read_idx))?,
+        cache_creation_input_tokens: match input_with_idx {
+            Some(idx) => parse_required(cell(idx))?,
+            None => 0,
+        },
+        ..TokenUsage::default()
+    })
 }
 
 /// Split one CSV record, honoring `"`-quoted fields with embedded commas and
@@ -515,6 +542,17 @@ mod tests {
     }
 
     #[test]
+    fn truncated_row_is_a_parse_error_not_a_zero() {
+        // A row that stops before the token columns must NOT read its missing
+        // cells as 0 — it's a parse error and contributes no event.
+        let csv = "Date,Model,Input (w/o Cache Write),Cache Read,Output Tokens\n\
+            \"2026-06-22T13:09:44Z\",\"m\"\n";
+        let collection = parse(csv, None);
+        assert!(collection.usage_events.is_empty());
+        assert_eq!(collection.stats.parse_errors, 1);
+    }
+
+    #[test]
     fn empty_token_cell_is_zero_not_a_drop() {
         // An absent value is a legitimate 0; the row is still recorded.
         let csv = "Date,Model,Input (w/o Cache Write),Cache Read,Output Tokens\n\
@@ -584,6 +622,11 @@ mod tests {
         assert_eq!(
             normalize_subject("microsoft|abc123").as_deref(),
             Some("microsoft|abc123")
+        );
+        // Email-based subjects from enterprise OIDC / SAML keep their `@`.
+        assert_eq!(
+            normalize_subject("okta|user@company.com").as_deref(),
+            Some("okta|user@company.com")
         );
         assert_eq!(normalize_subject("weird-value"), None);
         assert_eq!(normalize_subject("a|b|c"), None);

--- a/src/collector/cursor.rs
+++ b/src/collector/cursor.rs
@@ -203,17 +203,18 @@ fn normalize_subject(subject: &str) -> Option<String> {
     }
 }
 
-/// A non-empty `<provider>` / `<id>` half of a bridged-OAuth subject, restricted
-/// to characters safe to interpolate into a cookie value: no CR/LF, and none of
-/// the cookie metacharacters (`;`, `=`, `,`, space, `|`) that could split or
-/// confuse the header. `@` is allowed — it's a valid RFC 6265 cookie-octet and
-/// appears in email-based `sub` claims from enterprise OIDC / SAML providers, so
-/// rejecting it would silently lock out those accounts.
+/// A non-empty `<provider>` / `<id>` half of a bridged-OAuth subject that's safe
+/// to interpolate into a cookie value. The guard is a denylist, not a narrow
+/// allowlist: SSO subjects legitimately use `@`, `+`, `:`, etc. (all valid
+/// RFC 6265 cookie-octets), so only the characters that could actually break the
+/// header are rejected — ASCII control (incl CR/LF) and the cookie delimiters
+/// (space, `"`, `,`, `;`, `\`), plus a second `|` so each half stays a single
+/// segment. A narrower allowlist silently dropped enterprise/email accounts.
 fn is_safe_subject_part(part: &str) -> bool {
     !part.is_empty()
-        && part
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'@'))
+        && part.bytes().all(|byte| {
+            !byte.is_ascii_control() && !matches!(byte, b' ' | b'"' | b',' | b';' | b'\\' | b'|')
+        })
 }
 
 /// `GET` the usage CSV with the browser-equivalent headers. The `Err` carries a
@@ -623,10 +624,15 @@ mod tests {
             normalize_subject("microsoft|abc123").as_deref(),
             Some("microsoft|abc123")
         );
-        // Email-based subjects from enterprise OIDC / SAML keep their `@`.
+        // Email-based / tagged subjects from enterprise OIDC / SAML keep their
+        // `@`, `+`, `:` — all valid cookie-octets.
         assert_eq!(
             normalize_subject("okta|user@company.com").as_deref(),
             Some("okta|user@company.com")
+        );
+        assert_eq!(
+            normalize_subject("saml|alice+tag@example.com").as_deref(),
+            Some("saml|alice+tag@example.com")
         );
         assert_eq!(normalize_subject("weird-value"), None);
         assert_eq!(normalize_subject("a|b|c"), None);

--- a/src/format.rs
+++ b/src/format.rs
@@ -118,8 +118,13 @@ pub fn short_model_name(name: &str) -> String {
 /// separators, no control characters) and cap the length.
 fn sanitize_label(label: &str) -> String {
     const MAX: usize = 24;
+    // Bound the scan first: an untrusted name could be megabytes of disallowed
+    // characters, and `filter` alone would walk all of it before `take(MAX)`
+    // ever short-circuits. Only the first SCAN chars are ever examined.
+    const SCAN: usize = 128;
     let cleaned: String = label
         .chars()
+        .take(SCAN)
         .filter(|&ch| {
             ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '.' | '-' | '_' | '(' | ')' | '+')
         })

--- a/src/format.rs
+++ b/src/format.rs
@@ -126,6 +126,7 @@ fn sanitize_label(label: &str) -> String {
     // Bound the scan: an untrusted name could be megabytes long, and there's no
     // need to examine past the first SCAN characters to make this decision.
     const SCAN: usize = 128;
+    let label = label.trim();
     // `:` is allowed so local-model ids keep their tag (Ollama / OpenCode use
     // `qwen3:8b`-style names); path separators (`/`, `\`) stay out, so a smuggled
     // absolute path is still collapsed rather than published.
@@ -137,13 +138,15 @@ fn sanitize_label(label: &str) -> String {
     if label.is_empty() || label.chars().take(SCAN).any(|ch| !allowed(ch)) {
         return "Other".to_owned();
     }
-    let capped: String = label.chars().take(MAX).collect();
-    let trimmed = capped.trim();
-    if trimmed.is_empty() {
-        "Other".to_owned()
-    } else {
-        trimmed.to_owned()
+    // The label is already end-trimmed; only the MAX cut can leave a trailing
+    // space, so trim that in place instead of allocating a second string.
+    let mut capped: String = label.chars().take(MAX).collect();
+    let trimmed_len = capped.trim_end().len();
+    if trimmed_len == 0 {
+        return "Other".to_owned();
     }
+    capped.truncate(trimmed_len);
+    capped
 }
 
 /// Strip a *known* `<provider>/` namespace from a gateway/proxy model id (agent
@@ -179,7 +182,9 @@ fn strip_known_provider_prefix(name: &str) -> &str {
     ];
     if let Some((prefix, rest)) = name.split_once('/')
         && !rest.is_empty()
-        && PROVIDERS.contains(&prefix.to_ascii_lowercase().as_str())
+        && PROVIDERS
+            .iter()
+            .any(|known| known.eq_ignore_ascii_case(prefix))
     {
         return rest;
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -146,7 +146,48 @@ fn sanitize_label(label: &str) -> String {
     }
 }
 
+/// Strip a *known* `<provider>/` namespace from a gateway/proxy model id (agent
+/// runners and routers use `provider/model` ids), so the model shows by its real
+/// name. An *unknown* prefix is left intact — the surviving `/` then makes
+/// `sanitize_label` collapse it to "Other", which is what keeps an arbitrary
+/// `org/repo` (or a path) from reaching the card. A stale list degrades safely: a
+/// new provider's model just shows as "Other" until it's added here.
+fn strip_known_provider_prefix(name: &str) -> &str {
+    const PROVIDERS: &[&str] = &[
+        "openai",
+        "anthropic",
+        "google",
+        "vertex_ai",
+        "vertex",
+        "meta-llama",
+        "meta",
+        "mistralai",
+        "mistral",
+        "x-ai",
+        "xai",
+        "deepseek",
+        "qwen",
+        "cohere",
+        "perplexity",
+        "azure",
+        "bedrock",
+        "openrouter",
+        "together",
+        "fireworks",
+        "groq",
+        "ollama",
+    ];
+    if let Some((prefix, rest)) = name.split_once('/')
+        && !rest.is_empty()
+        && PROVIDERS.contains(&prefix.to_ascii_lowercase().as_str())
+    {
+        return rest;
+    }
+    name
+}
+
 fn short_model_name_raw(name: &str) -> String {
+    let name = strip_known_provider_prefix(name);
     let lower = name.to_ascii_lowercase();
     let family = if lower.contains("opus") {
         "Opus"
@@ -386,5 +427,18 @@ mod tests {
         );
         // A local-model id keeps its `:tag` (Ollama / OpenCode) — not collapsed.
         assert_eq!(short_model_name("qwen3:8b"), "qwen3:8b");
+    }
+
+    #[test]
+    fn strips_known_provider_namespace_but_collapses_unknown() {
+        // Gateway / OpenCode `provider/model` ids show by their real name.
+        assert_eq!(short_model_name("openai/gpt-4o"), "GPT 4o");
+        assert_eq!(short_model_name("google/gemini-2.5-pro"), "gemini-2.5-pro");
+        assert_eq!(short_model_name("anthropic/claude-opus-4-8"), "Opus 4.8");
+        assert_eq!(short_model_name("mistralai/mistral-large"), "mistral-large");
+        // An UNKNOWN prefix is not stripped, so the surviving '/' collapses it —
+        // a `org/repo` (or path) can't smuggle a repo name onto the card.
+        assert_eq!(short_model_name("myorg/secret-repo"), "Other");
+        assert_eq!(short_model_name("openai/secret/repo"), "Other");
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -113,24 +113,28 @@ pub fn short_model_name(name: &str) -> String {
 /// Clamp a model label to a safe shape. Model names come from untrusted logs, so
 /// a crafted one could smuggle a repo name, an absolute path, or a token-like
 /// string onto the shareable card / clipboard — artifacts meant to carry none.
-/// Well-known families already collapse to a constant, so in practice this only
-/// reshapes an unrecognized passthrough name: keep a small printable set (no path
-/// separators, no control characters) and cap the length.
+///
+/// Stripping disallowed characters is not enough: it would still publish the
+/// readable fragments of a smuggled path (`gemini/Users/alice/secret` →
+/// `geminiUsersalicesecret`). So a label containing anything outside the
+/// model-name character set is treated as suspicious and collapsed to a generic
+/// value. Legitimate names (which only use that set) pass through unchanged,
+/// capped for layout; well-known families have already collapsed to a constant
+/// upstream, so this only ever judges an unrecognized passthrough name.
 fn sanitize_label(label: &str) -> String {
     const MAX: usize = 24;
-    // Bound the scan first: an untrusted name could be megabytes of disallowed
-    // characters, and `filter` alone would walk all of it before `take(MAX)`
-    // ever short-circuits. Only the first SCAN chars are ever examined.
+    // Bound the scan: an untrusted name could be megabytes long, and there's no
+    // need to examine past the first SCAN characters to make this decision.
     const SCAN: usize = 128;
-    let cleaned: String = label
-        .chars()
-        .take(SCAN)
-        .filter(|&ch| {
-            ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '.' | '-' | '_' | '(' | ')' | '+')
-        })
-        .take(MAX)
-        .collect();
-    let trimmed = cleaned.trim();
+    let allowed = |ch: char| {
+        ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '.' | '-' | '_' | '(' | ')' | '+')
+    };
+    let prefix: String = label.chars().take(SCAN).collect();
+    if prefix.is_empty() || !prefix.chars().all(allowed) {
+        return "Other".to_owned();
+    }
+    let capped: String = prefix.chars().take(MAX).collect();
+    let trimmed = capped.trim();
     if trimmed.is_empty() {
         "Other".to_owned()
     } else {
@@ -358,22 +362,23 @@ mod tests {
     }
 
     #[test]
-    fn sanitizes_untrusted_model_names_for_the_card() {
-        // A crafted log model name can't smuggle a path, a newline, or angle
-        // brackets onto the shareable card — path separators and control/exotic
-        // characters are dropped and the label is length-capped.
-        let crafted = short_model_name("gemini/Users/secret/repo\n<script>");
-        assert!(!crafted.contains('/'));
-        assert!(!crafted.contains('\n'));
-        assert!(!crafted.contains('<'));
-        assert!(crafted.chars().count() <= 24);
-        // A legitimate display name with spaces and parens is preserved.
+    fn collapses_suspicious_model_names_for_the_card() {
+        // A crafted name containing a path / newline / angle brackets is
+        // collapsed to a generic label, NOT stripped-and-kept — so no readable
+        // repo or path fragment ("Users", "secret") reaches the card.
+        assert_eq!(
+            short_model_name("gemini/Users/secret/repo\n<script>"),
+            "Other"
+        );
+        // The gpt-prefixed passthrough is judged the same way.
+        assert_eq!(short_model_name("gpt-/etc/passwd"), "Other");
+        // Non-ASCII / control-only names collapse rather than yielding an empty
+        // chip.
+        assert_eq!(short_model_name("名前/\t"), "Other");
+        // A legitimate display name with spaces and parens is preserved verbatim.
         assert_eq!(
             short_model_name("Gemini 3.5 Flash (High)"),
             "Gemini 3.5 Flash (High)"
         );
-        // A name that's entirely disallowed characters collapses to "Other"
-        // rather than an empty chip.
-        assert_eq!(short_model_name("名前/\t"), "Other");
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -107,6 +107,33 @@ pub fn format_timestamp(timestamp: OffsetDateTime) -> String {
 }
 
 pub fn short_model_name(name: &str) -> String {
+    sanitize_label(&short_model_name_raw(name))
+}
+
+/// Clamp a model label to a safe shape. Model names come from untrusted logs, so
+/// a crafted one could smuggle a repo name, an absolute path, or a token-like
+/// string onto the shareable card / clipboard — artifacts meant to carry none.
+/// Well-known families already collapse to a constant, so in practice this only
+/// reshapes an unrecognized passthrough name: keep a small printable set (no path
+/// separators, no control characters) and cap the length.
+fn sanitize_label(label: &str) -> String {
+    const MAX: usize = 24;
+    let cleaned: String = label
+        .chars()
+        .filter(|&ch| {
+            ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '.' | '-' | '_' | '(' | ')' | '+')
+        })
+        .take(MAX)
+        .collect();
+    let trimmed = cleaned.trim();
+    if trimmed.is_empty() {
+        "Other".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+fn short_model_name_raw(name: &str) -> String {
     let lower = name.to_ascii_lowercase();
     let family = if lower.contains("opus") {
         "Opus"
@@ -323,5 +350,25 @@ mod tests {
         assert_eq!(short_model_name("claude-sonnet-4-5-20250929"), "Sonnet 4.5");
         assert_eq!(short_model_name("gpt-5.5"), "GPT 5.5");
         assert_eq!(short_model_name("custom-model"), "custom-model");
+    }
+
+    #[test]
+    fn sanitizes_untrusted_model_names_for_the_card() {
+        // A crafted log model name can't smuggle a path, a newline, or angle
+        // brackets onto the shareable card — path separators and control/exotic
+        // characters are dropped and the label is length-capped.
+        let crafted = short_model_name("gemini/Users/secret/repo\n<script>");
+        assert!(!crafted.contains('/'));
+        assert!(!crafted.contains('\n'));
+        assert!(!crafted.contains('<'));
+        assert!(crafted.chars().count() <= 24);
+        // A legitimate display name with spaces and parens is preserved.
+        assert_eq!(
+            short_model_name("Gemini 3.5 Flash (High)"),
+            "Gemini 3.5 Flash (High)"
+        );
+        // A name that's entirely disallowed characters collapses to "Other"
+        // rather than an empty chip.
+        assert_eq!(short_model_name("名前/\t"), "Other");
     }
 }

--- a/src/format.rs
+++ b/src/format.rs
@@ -126,14 +126,18 @@ fn sanitize_label(label: &str) -> String {
     // Bound the scan: an untrusted name could be megabytes long, and there's no
     // need to examine past the first SCAN characters to make this decision.
     const SCAN: usize = 128;
+    // `:` is allowed so local-model ids keep their tag (Ollama / OpenCode use
+    // `qwen3:8b`-style names); path separators (`/`, `\`) stay out, so a smuggled
+    // absolute path is still collapsed rather than published.
     let allowed = |ch: char| {
-        ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '.' | '-' | '_' | '(' | ')' | '+')
+        ch.is_ascii_alphanumeric() || matches!(ch, ' ' | '.' | '-' | '_' | '(' | ')' | '+' | ':')
     };
-    let prefix: String = label.chars().take(SCAN).collect();
-    if prefix.is_empty() || !prefix.chars().all(allowed) {
+    // Validate on the iterator (no temp allocation): a label is suspicious if
+    // it's empty or any of its first SCAN characters falls outside the set.
+    if label.is_empty() || label.chars().take(SCAN).any(|ch| !allowed(ch)) {
         return "Other".to_owned();
     }
-    let capped: String = prefix.chars().take(MAX).collect();
+    let capped: String = label.chars().take(MAX).collect();
     let trimmed = capped.trim();
     if trimmed.is_empty() {
         "Other".to_owned()
@@ -380,5 +384,7 @@ mod tests {
             short_model_name("Gemini 3.5 Flash (High)"),
             "Gemini 3.5 Flash (High)"
         );
+        // A local-model id keeps its `:tag` (Ollama / OpenCode) — not collapsed.
+        assert_eq!(short_model_name("qwen3:8b"), "qwen3:8b");
     }
 }


### PR DESCRIPTION
Follow-ups from a design/security second-opinion review of v0.6.0. All findings here are MEDIUM/LOW — no critical issues were found; the architecture and baseline security posture (saturating arithmetic, read-only SQLite, bounds-checked protobuf, token never logged) held up.

## Security

- **Cursor cookie can't leave cursor.com.** The usage fetch no longer follows redirects (`ureq` agent with `redirects(0)`), so a 3xx from the endpoint can't forward the hand-attached session cookie to another host. A redirect is refused instead of chased.
- **Cookie-header injection guard.** Session tokens with ASCII control characters (a CR/LF in a crafted `state.vscdb` or a malformed `CURSOR_TOKEN`) are rejected before building the cookie.
- **Token never in a debug dump.** `CursorConfig` now has a manual `Debug` that redacts the token, so a future `{config:?}` can't leak `CURSOR_TOKEN` to a log or panic message.
- **Card-label leak closed.** Model labels come from untrusted logs and were passed through raw for non-Claude families. They're now sanitized (printable set, length-capped, no path separators or control characters) before they can reach the shareable card / clipboard, so a crafted log can't smuggle a repo name, absolute path, or token-like string onto an artifact meant to carry none.

## Correctness

- **No silent wrong-zero.** A present-but-unparseable Cursor token cell (e.g. a thousands-separated `1,234` after a format change) now drops the row as a parse error instead of recording 0 tokens. Empty cells remain a legitimate 0. Degrade to less data, never a wrong number.

## Consent / docs

- **`--no-cursor`** disables the one network-reaching collector, keeping agent-walker fully offline.
- Fixed the stale `opt-in` comment on the Cursor collector.
- **`SECURITY.md`** now documents the Cursor session-cookie egress and lists every provider read (previously claimed "only network access is LiteLLM").
- **`docs/agy.md` / `README.md`** state honestly what the Antigravity per-row output-total check guarantees (catches field renumbering — the likely drift) and what it doesn't (an input-field re-meaning with no wire change, which no row-level checksum can catch).

## Testing

- `cargo fmt`, `cargo clippy --all-targets` clean, `cargo test` 96 passing (added: redirect/control-char/strict-parse/card-sanitize cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)