### PR TITLE
SKILLS / LIMITS / MODES: 30-day harness views from newly logged fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -322,3 +322,7 @@ credentials.json
 token.json
 *.pem
 *.key
+
+### Local agent notes (never tracked — operational meta stays out of the public repo)
+AGENTS.md
+CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Three new views of how you drive your agents, all cut on the fixed 30-day
+window and all TUI-only — the share card is untouched.
+
+### Added
+
+- **SKILLS** (Claude tab): token volume per skill, read from the
+  `attributionSkill` field recent Claude Code versions write. Shares are of
+  attributed volume; the subtitle carries the honest denominator ("attributed
+  N% of volume") since most tokens flow outside skills.
+- **LIMITS** (Codex tab): daily peak of the plan's 5-hour window utilization,
+  rebuilt from the `rate_limits` snapshots Codex rollouts record. Fixed
+  0-100% axis, red bar on limit-hit days, faint dot for days without Codex
+  use. History only, by design — this dashboard looks back, it doesn't
+  monitor.
+- **MODES** (per provider tab): each provider's own thinking dial — Claude
+  shows how often extended thinking actually fired (block presence only; the
+  text is never read) plus fast mode once it has data, Codex shows the
+  reasoning-effort mix from `turn_context`.
+
+### Fixed
+
+- Duplicate Claude log lines for the same message now merge their metadata
+  (attribution, model, project) instead of keeping only the larger-volume
+  line's fields.
+- `codex-auto-review` sessions are priced as the Codex default model instead
+  of silently costing $0.
+- The `--agy-dir` help text no longer claims Antigravity is activity-only —
+  token usage has been decoded from its conversation store since v0.7.
+
 ## [0.8.0] - 2026-07-08
 
 The codename becomes a rank you climb.

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -9,7 +9,8 @@ use std::collections::BTreeMap;
 use time::{Date, Duration, OffsetDateTime, UtcOffset};
 
 use crate::model::{
-    Collection, DailySessions, DailyStat, ModelDailyStat, Summary, TokenUsage, ToolStat,
+    Collection, DailySessions, DailyStat, LimitDay, LimitsHistory, ModelDailyStat, ModesSummary,
+    SkillStat, Summary, TokenUsage, ToolStat,
 };
 
 use self::aggregates::Aggregates;
@@ -159,6 +160,10 @@ pub fn summarize(
         period_end - Duration::days(crate::codename::CODENAME_WINDOW_DAYS - 1);
     let mut recent_window_volume = 0_u64;
     let mut recent_active_days = std::collections::HashSet::new();
+    // The v0.9 sections (SKILLS / LIMITS / MODES) share this fixed 30-day
+    // window: attribution fields exist only in recent logs, and the mode /
+    // limit views are "how you've been using it lately" by design.
+    let mut skill_map: BTreeMap<String, TokenUsage> = BTreeMap::new();
     for event in &collection.usage_events {
         let Some(date) = event.timestamp.map(|ts| ts.to_offset(local_offset).date()) else {
             continue;
@@ -172,7 +177,32 @@ pub fn summarize(
         }
         recent_window_volume = recent_window_volume.saturating_add(volume);
         recent_active_days.insert(date);
+        if let Some(skill) = &event.attribution_skill {
+            skill_map
+                .entry(skill.clone())
+                .or_default()
+                .add_assign(&event.usage);
+        }
     }
+    let mut skills = skill_map
+        .into_iter()
+        .map(|(name, usage)| SkillStat { name, usage })
+        .collect::<Vec<_>>();
+    skills.sort_by(|left, right| {
+        right
+            .usage
+            .token_volume()
+            .cmp(&left.usage.token_volume())
+            .then_with(|| left.name.cmp(&right.name))
+    });
+    let limits = limits_history(
+        collection,
+        codename_window_start,
+        period_end,
+        local_offset,
+        &recent_active_days,
+    );
+    let mode_usage = modes_summary(collection, codename_window_start, period_end, local_offset);
     let recent_window_active_days = recent_active_days.len();
 
     Summary {
@@ -190,6 +220,9 @@ pub fn summarize(
         model_daily,
         models,
         agents,
+        skills,
+        limits,
+        modes: mode_usage,
         tools,
         projects,
         sessions: aggregates.period_sessions.len(),
@@ -243,6 +276,95 @@ fn build_aggregates(
     aggregates
 }
 
+/// Daily-peak LIMITS history over the fixed 30-day window. Tri-state per day:
+/// a day with samples carries its peak `used_percent`; a day with provider
+/// activity but no sample (older CLI versions) is `NoSample`; a day without
+/// activity is `NoUse` — the chart renders the three differently, so a
+/// measured 0% is never confused with "didn't use Codex that day".
+fn limits_history(
+    collection: &Collection,
+    window_start: Date,
+    period_end: Date,
+    local_offset: UtcOffset,
+    active_days: &std::collections::HashSet<Date>,
+) -> Option<LimitsHistory> {
+    let mut daily_peak: BTreeMap<Date, f64> = BTreeMap::new();
+    for sample in &collection.rate_limit_samples {
+        let date = sample.timestamp.to_offset(local_offset).date();
+        if date < window_start || date > period_end {
+            continue;
+        }
+        let entry = daily_peak.entry(date).or_insert(0.0);
+        if sample.used_percent > *entry {
+            *entry = sample.used_percent;
+        }
+    }
+    if daily_peak.is_empty() {
+        return None;
+    }
+
+    let mut days = Vec::new();
+    let mut peak: Option<(Date, f64)> = None;
+    let mut date = window_start;
+    while date <= period_end {
+        let day = match daily_peak.get(&date) {
+            Some(&value) => {
+                if peak.is_none_or(|(_, best)| value > best) {
+                    peak = Some((date, value));
+                }
+                LimitDay::Measured(value)
+            }
+            None if active_days.contains(&date) => LimitDay::NoSample,
+            None => LimitDay::NoUse,
+        };
+        days.push((date, day));
+        date += Duration::days(1);
+    }
+    Some(LimitsHistory { days, peak })
+}
+
+/// Mode usage over the fixed 30-day window: Claude thinking / fast flags per
+/// assistant message, Codex reasoning-effort per turn.
+fn modes_summary(
+    collection: &Collection,
+    window_start: Date,
+    period_end: Date,
+    local_offset: UtcOffset,
+) -> ModesSummary {
+    let in_window = |timestamp: Option<OffsetDateTime>| {
+        timestamp
+            .map(|ts| ts.to_offset(local_offset).date())
+            .is_some_and(|date| date >= window_start && date <= period_end)
+    };
+
+    let mut modes = ModesSummary::default();
+    for event in &collection.mode_events {
+        if !in_window(event.timestamp) {
+            continue;
+        }
+        modes.assistant_turns += 1;
+        if event.has_thinking {
+            modes.thinking_turns += 1;
+        }
+        if event.fast {
+            modes.fast_turns += 1;
+        }
+    }
+
+    let mut effort_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for event in &collection.effort_events {
+        if !in_window(event.timestamp) {
+            continue;
+        }
+        *effort_counts.entry(event.effort.clone()).or_default() += 1;
+    }
+    modes.efforts = effort_counts.into_iter().collect();
+    modes
+        .efforts
+        .sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    modes
+}
+
 fn init_daily_usage(period_start: Date, period_days: u16) -> BTreeMap<Date, TokenUsage> {
     (0..period_days)
         .map(|offset| {
@@ -276,6 +398,7 @@ mod tests {
                     model: Some("claude-opus-4-8".to_owned()),
                     source_kind: SourceKind::Main,
                     attribution_agent: None,
+                    attribution_skill: None,
                     project: Some("orchestra".to_owned()),
                     usage: TokenUsage {
                         input_tokens: 10,
@@ -292,6 +415,7 @@ mod tests {
                     model: Some("claude-haiku-4-5".to_owned()),
                     source_kind: SourceKind::Subagent,
                     attribution_agent: Some("Explore".to_owned()),
+                    attribution_skill: None,
                     project: Some("orchestra".to_owned()),
                     usage: TokenUsage {
                         input_tokens: 5,
@@ -333,6 +457,9 @@ mod tests {
                 },
             ],
             duration_events: Vec::new(),
+            rate_limit_samples: Vec::new(),
+            effort_events: Vec::new(),
+            mode_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -365,6 +492,7 @@ mod tests {
             model: Some("claude-opus-4-8".to_owned()),
             source_kind: SourceKind::Main,
             attribution_agent: None,
+            attribution_skill: None,
             project: None,
             usage: TokenUsage {
                 input_tokens: tokens,
@@ -385,6 +513,9 @@ mod tests {
             tool_events: Vec::new(),
             session_touches: Vec::new(),
             duration_events: Vec::new(),
+            rate_limit_samples: Vec::new(),
+            effort_events: Vec::new(),
+            mode_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -416,6 +547,7 @@ mod tests {
             model: Some("shared-model".to_owned()),
             source_kind: SourceKind::Main,
             attribution_agent: None,
+            attribution_skill: None,
             project: None,
             usage: usage(input),
             reported_cost_usd: reported,
@@ -427,6 +559,9 @@ mod tests {
             tool_events: Vec::new(),
             session_touches: Vec::new(),
             duration_events: Vec::new(),
+            rate_limit_samples: Vec::new(),
+            effort_events: Vec::new(),
+            mode_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -448,5 +583,145 @@ mod tests {
             .expect("model-day present");
         assert_eq!(day.reported_cost_usd, Some(0.5));
         assert_eq!(day.unreported_usage.input_tokens, 300);
+    }
+}
+
+#[cfg(test)]
+mod v09_tests {
+    use time::macros::{date, datetime};
+
+    use super::*;
+    use crate::model::{
+        Collection, EffortEvent, ModeEvent, Provider, RateLimitSample, ScanStats, SourceKind,
+        UsageEvent,
+    };
+
+    fn skill_event(at: OffsetDateTime, skill: Option<&str>, tokens: u64) -> UsageEvent {
+        UsageEvent {
+            timestamp: Some(at),
+            session_id: Some("s".to_owned()),
+            model: Some("claude-fable-5".to_owned()),
+            source_kind: SourceKind::Main,
+            attribution_agent: None,
+            attribution_skill: skill.map(ToOwned::to_owned),
+            project: None,
+            usage: TokenUsage {
+                input_tokens: tokens,
+                ..TokenUsage::default()
+            },
+            reported_cost_usd: None,
+        }
+    }
+
+    /// SKILLS / LIMITS / MODES all cut on the fixed 30-day codename window
+    /// (display `--days` = 90 here), and LIMITS days are tri-state.
+    #[test]
+    fn v09_sections_use_fixed_window_and_tristate_days() {
+        let now = datetime!(2026-06-30 12:00 UTC);
+        let collection = Collection {
+            provider: Provider::Combined,
+            root: "/tmp".into(),
+            usage_events: vec![
+                // In the 30d window (06-01..06-30) with a skill.
+                skill_event(
+                    datetime!(2026-06-25 10:00 UTC),
+                    Some("sk:review"),
+                    1_000_000,
+                ),
+                // In the 90d display window but OUTSIDE the fixed 30d window:
+                // must not appear in SKILLS.
+                skill_event(
+                    datetime!(2026-05-20 10:00 UTC),
+                    Some("sk:review"),
+                    2_000_000,
+                ),
+                // Active day without any rate-limit sample -> NoSample.
+                skill_event(datetime!(2026-06-22 09:00 UTC), None, 500),
+            ],
+            tool_events: Vec::new(),
+            session_touches: Vec::new(),
+            duration_events: Vec::new(),
+            rate_limit_samples: vec![
+                RateLimitSample {
+                    timestamp: datetime!(2026-06-22 08:00 UTC),
+                    used_percent: 40.0,
+                },
+                // Same day, later, higher: the day keeps its PEAK.
+                RateLimitSample {
+                    timestamp: datetime!(2026-06-22 09:01 UTC),
+                    used_percent: 100.0,
+                },
+                // Outside the 30d window: ignored.
+                RateLimitSample {
+                    timestamp: datetime!(2026-05-20 09:00 UTC),
+                    used_percent: 90.0,
+                },
+            ],
+            effort_events: vec![
+                EffortEvent {
+                    timestamp: Some(datetime!(2026-06-25 10:00 UTC)),
+                    effort: "xhigh".to_owned(),
+                },
+                EffortEvent {
+                    timestamp: Some(datetime!(2026-06-25 11:00 UTC)),
+                    effort: "xhigh".to_owned(),
+                },
+                EffortEvent {
+                    timestamp: Some(datetime!(2026-06-25 12:00 UTC)),
+                    effort: "low".to_owned(),
+                },
+            ],
+            mode_events: vec![
+                ModeEvent {
+                    timestamp: Some(datetime!(2026-06-25 10:00 UTC)),
+                    has_thinking: true,
+                    fast: false,
+                },
+                ModeEvent {
+                    timestamp: Some(datetime!(2026-06-25 11:00 UTC)),
+                    has_thinking: false,
+                    fast: false,
+                },
+                // Outside the 30d window: ignored.
+                ModeEvent {
+                    timestamp: Some(datetime!(2026-05-20 10:00 UTC)),
+                    has_thinking: true,
+                    fast: true,
+                },
+            ],
+            stats: ScanStats::default(),
+        };
+
+        let summary = summarize(&collection, now, 90, UtcOffset::UTC);
+
+        // SKILLS: only the in-window 1M event counts.
+        assert_eq!(summary.skills.len(), 1);
+        assert_eq!(summary.skills[0].name, "sk:review");
+        assert_eq!(summary.skills[0].usage.token_volume(), 1_000_000);
+
+        // LIMITS: 30 tri-state days, daily PEAK, window-filtered.
+        let limits = summary.limits.expect("limits history should exist");
+        assert_eq!(limits.days.len(), 30);
+        assert_eq!(limits.peak, Some((date!(2026 - 06 - 22), 100.0)));
+        let day = |d: Date| {
+            limits
+                .days
+                .iter()
+                .find(|(date, _)| *date == d)
+                .map(|(_, day)| *day)
+                .expect("day should be in window")
+        };
+        assert_eq!(day(date!(2026 - 06 - 22)), LimitDay::Measured(100.0));
+        assert_eq!(day(date!(2026 - 06 - 25)), LimitDay::NoSample);
+        assert_eq!(day(date!(2026 - 06 - 03)), LimitDay::NoUse);
+
+        // MODES: window-filtered turns and effort distribution.
+        assert_eq!(summary.modes.assistant_turns, 2);
+        assert_eq!(summary.modes.thinking_turns, 1);
+        assert_eq!(summary.modes.fast_turns, 0);
+        assert_eq!(
+            summary.modes.efforts,
+            vec![("xhigh".to_owned(), 2), ("low".to_owned(), 1)]
+        );
     }
 }

--- a/src/analyzer/concurrency.rs
+++ b/src/analyzer/concurrency.rs
@@ -132,6 +132,9 @@ mod tests {
             tool_events: Vec::new(),
             session_touches: touches,
             duration_events: Vec::new(),
+            rate_limit_samples: Vec::new(),
+            effort_events: Vec::new(),
+            mode_events: Vec::new(),
             stats: ScanStats::default(),
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,9 +32,9 @@ pub struct Args {
     pub codex_dir: Option<PathBuf>,
 
     /// Override the Antigravity log directory. Antigravity is auto-detected:
-    /// its tab appears only when logs are present. Its logs expose no token
-    /// usage (an unlabeled protobuf store), so the tab is activity-only and
-    /// never feeds the token totals.
+    /// its tab appears only when logs are present. Text logs supply activity
+    /// only; token usage is decoded from the conversation store, so the tab
+    /// feeds the token totals like every other provider.
     #[arg(long, value_name = "DIR")]
     pub agy_dir: Option<PathBuf>,
 
@@ -301,8 +301,7 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
             // Antigravity and OpenCode are probed whenever their directory
             // resolved; the collector returns an empty collection for a missing
             // dir / DB, and an empty provider is filtered out before it ever
-            // becomes a tab. (Antigravity logs carry no token usage; OpenCode's
-            // SQLite store does.)
+            // becomes a tab.
             let agy_handle = scope.spawn(|| {
                 config.agy_dir.as_ref().map(|dir| {
                     agy::collect(dir, mtime_floor, config.use_cache, config.local_offset)
@@ -462,6 +461,9 @@ mod tests {
             }],
             models: Vec::new(),
             agents: Vec::new(),
+            skills: Vec::new(),
+            limits: None,
+            modes: crate::model::ModesSummary::default(),
             tools: Vec::new(),
             projects: Vec::new(),
             sessions: 0,

--- a/src/collector/agy_conv.rs
+++ b/src/collector/agy_conv.rs
@@ -264,6 +264,7 @@ fn parse_gen(
         model,
         source_kind: SourceKind::Main,
         attribution_agent: None,
+        attribution_skill: None,
         project: project.map(project_from_cwd),
         usage,
         reported_cost_usd: None,

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -8,12 +8,12 @@ use time::format_description::well_known::Rfc3339;
 use time::{Duration, OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached,
-    project_from_cwd,
+    FileEvents, KeyedModeEvent, KeyedToolEvent, KeyedUsageEvent, list_files, merge_into,
+    parse_files_cached, project_from_cwd,
 };
 use crate::model::{
-    Collection, DurationEvent, Provider, SessionTouch, SourceKind, TokenUsage, ToolEvent,
-    UsageEvent,
+    Collection, DurationEvent, ModeEvent, Provider, SessionTouch, SourceKind, TokenUsage,
+    ToolEvent, UsageEvent,
 };
 
 /// Background/observer harnesses (e.g. the claude-mem observer) keep
@@ -255,10 +255,14 @@ fn parse_line(
                 None
             }
         });
+    let attribution_skill = string_field(value, "attributionSkill")
+        .or_else(|| string_field(value, "attribution_skill"));
 
     let Some(message) = value.get("message") else {
         return;
     };
+
+    collect_mode_event(value, message, timestamp, events);
 
     if let Some(usage) = parse_usage(message.get("usage").or_else(|| value.get("usage"))) {
         let model = string_field(message, "model").or_else(|| string_field(value, "model"));
@@ -270,6 +274,7 @@ fn parse_line(
                 model,
                 source_kind: event_source_kind,
                 attribution_agent: attribution_agent.clone(),
+                attribution_skill,
                 project: project.map(ToOwned::to_owned),
                 usage,
                 reported_cost_usd: None,
@@ -286,6 +291,45 @@ fn parse_line(
         line_index,
         events,
     );
+}
+
+/// One mode event per assistant message (keyed by message id): did extended
+/// thinking fire (a `thinking` content block exists — presence only, the text
+/// is never read), and did fast mode serve it (`usage.speed == "fast"`).
+/// Streaming duplicates of the same message merge with OR in `merge_into`.
+fn collect_mode_event(
+    value: &Value,
+    message: &Value,
+    timestamp: Option<OffsetDateTime>,
+    events: &mut FileEvents,
+) {
+    if value.get("type").and_then(Value::as_str) != Some("assistant") {
+        return;
+    }
+    let Some(message_id) = string_field(message, "id") else {
+        return;
+    };
+    let has_thinking = message
+        .get("content")
+        .and_then(Value::as_array)
+        .is_some_and(|blocks| {
+            blocks
+                .iter()
+                .any(|block| block.get("type").and_then(Value::as_str) == Some("thinking"))
+        });
+    let fast = message
+        .get("usage")
+        .and_then(|usage| usage.get("speed"))
+        .and_then(Value::as_str)
+        == Some("fast");
+    events.mode_events.push(KeyedModeEvent {
+        key: Some(format!("mode:{message_id}")),
+        event: ModeEvent {
+            timestamp,
+            has_thinking,
+            fast,
+        },
+    });
 }
 
 fn collect_tool_events(
@@ -447,6 +491,67 @@ mod tests {
             collection.tool_events[0].subagent_type.as_deref(),
             Some("Explore")
         );
+    }
+
+    #[test]
+    fn collects_skill_attribution_and_mode_events() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","attributionSkill":"sk:review","message":{"id":"m1","model":"claude-fable-5","usage":{"input_tokens":10,"output_tokens":3,"speed":"fast"},"content":[{"type":"thinking","thinking":"…"},{"type":"text","text":"hi"}]}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:01:00Z","sessionId":"s1","type":"assistant","message":{"id":"m2","model":"claude-fable-5","usage":{"input_tokens":5,"output_tokens":2},"content":[{"type":"text","text":"plain"}]}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(
+            collection.usage_events[0].attribution_skill.as_deref(),
+            Some("sk:review")
+        );
+        assert_eq!(collection.usage_events[1].attribution_skill, None);
+        // One mode event per assistant message: thinking+fast, then neither.
+        assert_eq!(collection.mode_events.len(), 2);
+        assert!(collection.mode_events[0].has_thinking);
+        assert!(collection.mode_events[0].fast);
+        assert!(!collection.mode_events[1].has_thinking);
+        assert!(!collection.mode_events[1].fast);
+    }
+
+    /// Streaming duplicates of one message can disagree: the larger-volume
+    /// line may lack attribution while a smaller fragment carries it. The
+    /// winner keeps its tokens but absorbs the loser's metadata (fill), and
+    /// mode flags merge with OR.
+    #[test]
+    fn duplicate_lines_fill_metadata_instead_of_dropping_it() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","message":{"id":"m1","model":"claude-fable-5","usage":{"input_tokens":100,"output_tokens":50},"content":[{"type":"text","text":"big"}]}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:01Z","sessionId":"s1","type":"assistant","attributionSkill":"sk:review","message":{"id":"m1","model":"claude-fable-5","usage":{"input_tokens":1,"output_tokens":1},"content":[{"type":"thinking","thinking":"…"}]}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        // One deduped usage event: the big line's tokens, the small line's skill.
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.usage_events[0].usage.input_tokens, 100);
+        assert_eq!(
+            collection.usage_events[0].attribution_skill.as_deref(),
+            Some("sk:review")
+        );
+        // One deduped mode event with OR-merged thinking.
+        assert_eq!(collection.mode_events.len(), 1);
+        assert!(collection.mode_events[0].has_thinking);
     }
 
     #[test]

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -9,12 +9,12 @@ use time::format_description::well_known::Rfc3339;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached,
-    project_from_cwd,
+    FileEvents, KeyedEffortEvent, KeyedRateLimitSample, KeyedToolEvent, KeyedUsageEvent,
+    list_files, merge_into, parse_files_cached, project_from_cwd,
 };
 use crate::model::{
-    Collection, DurationEvent, Provider, SessionTouch, SourceKind, TokenUsage, ToolEvent,
-    UsageEvent,
+    Collection, DurationEvent, EffortEvent, Provider, RateLimitSample, SessionTouch, SourceKind,
+    TokenUsage, ToolEvent, UsageEvent,
 };
 
 pub fn collect(
@@ -104,6 +104,13 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
         }
         if value.get("type").and_then(Value::as_str) == Some("turn_context") {
             current_model = string_path(&value, &["payload", "model"]).or(current_model);
+            collect_effort_event(
+                &value,
+                timestamp,
+                current_session_id.as_ref(),
+                line_index,
+                &mut events,
+            );
         }
 
         if let (Some(timestamp), Some(session_id)) = (timestamp, current_session_id.as_ref()) {
@@ -156,6 +163,7 @@ fn collect_usage_event(
     if string_path(value, &["payload", "type"]).as_deref() != Some("token_count") {
         return;
     }
+    collect_rate_limit_sample(value, timestamp, session_id, line_index, events);
     let Some(last_usage) = value
         .get("payload")
         .and_then(|payload| payload.get("info"))
@@ -192,10 +200,74 @@ fn collect_usage_event(
             model: model.cloned().or_else(|| Some("codex".to_owned())),
             source_kind: SourceKind::Main,
             attribution_agent: None,
+            attribution_skill: None,
             project: project.map(ToOwned::to_owned),
             usage,
             reported_cost_usd: None,
         },
+    });
+}
+
+/// Rate-limit snapshot riding on a `token_count` event: the plan's primary
+/// (5h) window utilization at that moment. Only the primary window is kept —
+/// the weekly window was deliberately dropped from the LIMITS history (a
+/// 30-day view of a 7-day window nests confusingly). Keyed like usage events
+/// so a copied rollout file can't double-sample a day.
+fn collect_rate_limit_sample(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    line_index: usize,
+    events: &mut FileEvents,
+) {
+    let Some(timestamp) = timestamp else {
+        return;
+    };
+    let Some(used_percent) = value
+        .get("payload")
+        .and_then(|payload| payload.get("rate_limits"))
+        .and_then(|limits| limits.get("primary"))
+        .and_then(|primary| primary.get("used_percent"))
+        .and_then(Value::as_f64)
+    else {
+        return;
+    };
+    let key = session_id.map(|sid| {
+        format!(
+            "codex-limit:{sid}:{ts}:{line_index}",
+            ts = timestamp.unix_timestamp_nanos(),
+        )
+    });
+    events.rate_limit_samples.push(KeyedRateLimitSample {
+        key,
+        event: RateLimitSample {
+            timestamp,
+            used_percent: used_percent.clamp(0.0, 100.0),
+        },
+    });
+}
+
+/// Reasoning-effort setting for one turn (`turn_context.payload.effort`).
+fn collect_effort_event(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    line_index: usize,
+    events: &mut FileEvents,
+) {
+    let Some(effort) = string_path(value, &["payload", "effort"]) else {
+        return;
+    };
+    let key = match (session_id, timestamp) {
+        (Some(sid), Some(ts)) => Some(format!(
+            "codex-effort:{sid}:{ts}:{line_index}",
+            ts = ts.unix_timestamp_nanos(),
+        )),
+        _ => None,
+    };
+    events.effort_events.push(KeyedEffortEvent {
+        key,
+        event: EffortEvent { timestamp, effort },
     });
 }
 
@@ -504,6 +576,37 @@ mod tests {
         assert_eq!(collection.tool_events[0].tool_name, "exec_command");
         assert_eq!(collection.duration_events.len(), 1);
         assert_eq!(collection.duration_events[0].duration_ms, 12_345);
+    }
+
+    #[test]
+    fn collects_effort_and_rate_limit_samples() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        let day = temp.path().join("2026/06/01");
+        fs::create_dir_all(&day).expect("test dirs should be created");
+        fs::write(
+            day.join("rollout-session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"xhigh"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110}},"rate_limits":{"primary":{"used_percent":37.5,"window_minutes":300},"secondary":{"used_percent":12.0,"window_minutes":10080}}}}"#,
+                "\n",
+                // A turn_context without effort contributes no effort event.
+                r#"{"timestamp":"2026-06-01T00:00:04Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.effort_events.len(), 1);
+        assert_eq!(collection.effort_events[0].effort, "xhigh");
+        // Only the PRIMARY (5h) window is sampled; the weekly window is
+        // deliberately dropped from the LIMITS history.
+        assert_eq!(collection.rate_limit_samples.len(), 1);
+        assert!((collection.rate_limit_samples[0].used_percent - 37.5).abs() < f64::EPSILON);
     }
 
     /// Each `token_count` line carries a (session, timestamp, `line_index`)

--- a/src/collector/cursor.rs
+++ b/src/collector/cursor.rs
@@ -361,6 +361,7 @@ fn parse_csv(
             model,
             source_kind: SourceKind::Main,
             attribution_agent: None,
+            attribution_skill: None,
             project: None, // Cursor usage events carry no project identifier.
             usage,
             reported_cost_usd,

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -15,7 +15,10 @@ use serde::{Deserialize, Serialize};
 use time::{Date, OffsetDateTime, UtcOffset};
 use tracing::debug;
 
-use crate::model::{Collection, DurationEvent, ScanStats, SessionTouch, ToolEvent, UsageEvent};
+use crate::model::{
+    Collection, DurationEvent, EffortEvent, ModeEvent, RateLimitSample, ScanStats, SessionTouch,
+    ToolEvent, UsageEvent,
+};
 
 /// Bump whenever the serialized layout of a cached `FileEvents` changes —
 /// stale caches would otherwise deserialize into garbage.
@@ -24,9 +27,11 @@ use crate::model::{Collection, DurationEvent, ScanStats, SessionTouch, ToolEvent
 ///   version bump OR a changed `local_offset`, recorded in
 ///   `CacheFile::offset_seconds`, so a machine-TZ change rebuilds automatically).
 /// - 8: `UsageEvent` gained `reported_cost_usd`, changing its bincode layout.
+/// - 9: v0.9 events — `UsageEvent.attribution_skill`, plus rate-limit /
+///   effort / mode event lists on `FileEvents`.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
-const CACHE_VERSION: u32 = 8;
+const CACHE_VERSION: u32 = 9;
 
 /// Normalize a working-directory path into a project label: strip the home
 /// prefix and (on Windows) normalize separators to `/` so the same repo
@@ -113,6 +118,9 @@ pub struct FileEvents {
     pub tool_events: Vec<KeyedToolEvent>,
     pub session_touches: Vec<SessionTouch>,
     pub duration_events: Vec<DurationEvent>,
+    pub rate_limit_samples: Vec<KeyedRateLimitSample>,
+    pub effort_events: Vec<KeyedEffortEvent>,
+    pub mode_events: Vec<KeyedModeEvent>,
     pub lines_seen: usize,
     pub parse_errors: usize,
 }
@@ -129,6 +137,27 @@ pub struct KeyedUsageEvent {
 pub struct KeyedToolEvent {
     pub key: Option<String>,
     pub event: ToolEvent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedRateLimitSample {
+    pub key: Option<String>,
+    pub event: RateLimitSample,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedEffortEvent {
+    pub key: Option<String>,
+    pub event: EffortEvent,
+}
+
+/// Mode event keyed by message id. Duplicate lines for the same message can
+/// disagree (a streaming fragment without the thinking block yet), so
+/// duplicates merge with OR semantics instead of being dropped.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedModeEvent {
+    pub key: Option<String>,
+    pub event: ModeEvent,
 }
 
 impl FileEvents {
@@ -392,12 +421,49 @@ pub fn parse_files_cached(
     results
 }
 
+/// Fill missing metadata on `target` from `source`. Duplicate keyed usage
+/// lines can carry different metadata (a streaming fragment has the tokens
+/// but not yet the attribution fields), so whichever variant wins on token
+/// volume must still absorb the other's metadata instead of discarding it.
+fn fill_usage_metadata(target: &mut UsageEvent, source: &UsageEvent) {
+    if target.timestamp.is_none() {
+        target.timestamp = source.timestamp;
+    }
+    if target.session_id.is_none() {
+        target.session_id.clone_from(&source.session_id);
+    }
+    if target.model.is_none() {
+        target.model.clone_from(&source.model);
+    }
+    if target.attribution_agent.is_none() {
+        target
+            .attribution_agent
+            .clone_from(&source.attribution_agent);
+    }
+    if target.attribution_skill.is_none() {
+        target
+            .attribution_skill
+            .clone_from(&source.attribution_skill);
+    }
+    if target.project.is_none() {
+        target.project.clone_from(&source.project);
+    }
+    if target.reported_cost_usd.is_none() {
+        target.reported_cost_usd = source.reported_cost_usd;
+    }
+}
+
 /// Merge ordered per-file events into the collection, applying cross-file
 /// deduplication. Keyed usage duplicates keep the variant with the larger
-/// token volume; keyed tool duplicates are dropped.
+/// token volume but fill missing metadata from the loser; keyed tool /
+/// rate-limit / effort duplicates are dropped; keyed mode duplicates merge
+/// their flags with OR.
 pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<FileEvents>)>) {
     let mut seen_usage: HashMap<String, usize> = HashMap::new();
     let mut seen_tools: HashSet<String> = HashSet::new();
+    let mut seen_limits: HashSet<String> = HashSet::new();
+    let mut seen_efforts: HashSet<String> = HashSet::new();
+    let mut seen_modes: HashMap<String, usize> = HashMap::new();
 
     for (path, events) in per_file {
         collection.stats.files_seen += 1;
@@ -415,10 +481,13 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
             match keyed.key {
                 Some(key) => {
                     if let Some(index) = seen_usage.get(&key).copied() {
-                        if keyed.event.usage.token_volume()
-                            > collection.usage_events[index].usage.token_volume()
-                        {
-                            collection.usage_events[index] = keyed.event;
+                        let existing = &mut collection.usage_events[index];
+                        if keyed.event.usage.token_volume() > existing.usage.token_volume() {
+                            let mut incoming = keyed.event;
+                            fill_usage_metadata(&mut incoming, existing);
+                            *existing = incoming;
+                        } else {
+                            fill_usage_metadata(existing, &keyed.event);
                         }
                     } else {
                         seen_usage.insert(key, collection.usage_events.len());
@@ -437,6 +506,47 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
                     }
                 }
                 None => collection.tool_events.push(keyed.event),
+            }
+        }
+
+        for keyed in events.rate_limit_samples {
+            match keyed.key {
+                Some(key) => {
+                    if seen_limits.insert(key) {
+                        collection.rate_limit_samples.push(keyed.event);
+                    }
+                }
+                None => collection.rate_limit_samples.push(keyed.event),
+            }
+        }
+
+        for keyed in events.effort_events {
+            match keyed.key {
+                Some(key) => {
+                    if seen_efforts.insert(key) {
+                        collection.effort_events.push(keyed.event);
+                    }
+                }
+                None => collection.effort_events.push(keyed.event),
+            }
+        }
+
+        for keyed in events.mode_events {
+            match keyed.key {
+                Some(key) => {
+                    if let Some(index) = seen_modes.get(&key).copied() {
+                        let existing = &mut collection.mode_events[index];
+                        existing.has_thinking |= keyed.event.has_thinking;
+                        existing.fast |= keyed.event.fast;
+                        if existing.timestamp.is_none() {
+                            existing.timestamp = keyed.event.timestamp;
+                        }
+                    } else {
+                        seen_modes.insert(key, collection.mode_events.len());
+                        collection.mode_events.push(keyed.event);
+                    }
+                }
+                None => collection.mode_events.push(keyed.event),
             }
         }
     }

--- a/src/collector/opencode.rs
+++ b/src/collector/opencode.rs
@@ -228,6 +228,7 @@ fn parse_messages(
                 .map(ToOwned::to_owned),
             source_kind: SourceKind::Main,
             attribution_agent: None,
+            attribution_skill: None,
             project: value
                 .pointer("/path/cwd")
                 .and_then(Value::as_str)

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -189,9 +189,10 @@ fn normalize(model_name: &str) -> String {
 /// ids misprice.
 pub fn pricing_for(model_name: &str) -> Option<Pricing> {
     let mut name = normalize(model_name);
-    if name == "codex" || name == "openai" {
-        // Codex sessions occasionally log only the provider name; price them
-        // as the current Codex default model.
+    if name == "codex" || name == "openai" || name == "codex-auto-review" {
+        // Codex sessions occasionally log only the provider name, and the
+        // automated-review flow logs `codex-auto-review` — neither has a
+        // LiteLLM key. Price both as the current Codex default model.
         "gpt-5.5".clone_into(&mut name);
     }
 
@@ -275,6 +276,7 @@ mod tests {
                     "claude-opus-4-8".to_owned(),
                     per_mtok(5.0, 25.0, 6.25, 10.0),
                 ),
+                ("claude-fable-5".to_owned(), per_mtok(8.0, 40.0, 10.0, 16.0)),
                 (
                     "claude-sonnet-4-5".to_owned(),
                     per_mtok(3.0, 15.0, 3.75, 6.0),
@@ -395,6 +397,25 @@ mod tests {
         let cost = usage_cost_usd("gpt-5.5", &usage).expect("gpt should be priced");
         assert!((cost - 40.0).abs() < 1e-9);
         assert!(usage_cost_usd("totally-unknown-model", &usage).is_none());
+    }
+
+    #[test]
+    fn prices_current_model_ids() {
+        install_test_pricing();
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            ..TokenUsage::default()
+        };
+        // The live LiteLLM snapshot carries exact keys for claude-fable-5 /
+        // claude-opus-4-8 / gpt-5.5 (verified 2026-07-08); the resolver must
+        // hit them without suffix games.
+        let fable = usage_cost_usd("claude-fable-5", &usage).expect("fable should be priced");
+        assert!((fable - 8.0).abs() < 1e-9);
+        // `codex-auto-review` has no LiteLLM key upstream; it prices as the
+        // Codex default model via the provider-name alias.
+        let review =
+            usage_cost_usd("codex-auto-review", &usage).expect("auto-review should be priced");
+        assert!((review - 5.0).abs() < 1e-9);
     }
 
     #[test]

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -11,8 +11,8 @@ use time::{Duration, OffsetDateTime, Time, Weekday};
 use crate::analyzer::summarize;
 use crate::app::Config;
 use crate::model::{
-    AppSummary, Collection, DurationEvent, Provider, SessionTouch, SourceKind, TokenUsage,
-    ToolEvent, UsageEvent,
+    AppSummary, Collection, DurationEvent, EffortEvent, ModeEvent, Provider, RateLimitSample,
+    SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
 };
 
 struct Rng(u64);
@@ -59,6 +59,33 @@ const CLAUDE_TOOLS: [(&str, u64); 8] = [
 ];
 
 const SUBAGENTS: [&str; 3] = ["Explore", "general-purpose", "code-reviewer"];
+
+/// Demo skill labels for the SKILLS section (Claude attribution).
+const SKILLS: [&str; 6] = [
+    "sk:review",
+    "sk:release",
+    "orc:inbox",
+    "deep-research",
+    "loop",
+    "ref:api",
+];
+
+fn pick_skill(rng: &mut Rng, progress: f64) -> Option<String> {
+    // Attribution fields only exist in recent logs; mirror that by tagging
+    // mostly late-period events, at a modest rate like real data.
+    if progress < 0.4 || !rng.chance(35) {
+        return None;
+    }
+    let index = match rng.range(0, 100) {
+        0..=29 => 0,
+        30..=54 => 1,
+        55..=74 => 2,
+        75..=86 => 3,
+        87..=94 => 4,
+        _ => 5,
+    };
+    Some(SKILLS[index].to_owned())
+}
 
 const CODEX_TOOLS: [(&str, u64); 4] = [
     ("shell", 55),
@@ -214,9 +241,15 @@ fn claude_collection(now: OffsetDateTime, days: u16, rng: &mut Rng) -> Collectio
                     model: Some(pick_claude_model(rng, progress).to_owned()),
                     source_kind: SourceKind::Main,
                     attribution_agent: None,
+                    attribution_skill: pick_skill(rng, progress),
                     project: Some(pick_project(rng)),
                     usage: usage_block(rng, session_volume / chunks),
                     reported_cost_usd: None,
+                });
+                collection.mode_events.push(ModeEvent {
+                    timestamp: Some(timestamp),
+                    has_thinking: rng.chance(52),
+                    fast: false,
                 });
 
                 for (tool, weight) in CLAUDE_TOOLS {
@@ -296,9 +329,25 @@ fn codex_collection(now: OffsetDateTime, days: u16, rng: &mut Rng) -> Collection
             model: Some("gpt-5.5".to_owned()),
             source_kind: SourceKind::Main,
             attribution_agent: None,
+            attribution_skill: None,
             project: Some(pick_project(rng)),
             usage: usage_block(rng, volume),
             reported_cost_usd: None,
+        });
+        collection.effort_events.push(EffortEvent {
+            timestamp: Some(timestamp),
+            effort: if rng.chance(88) { "xhigh" } else { "low" }.to_owned(),
+        });
+        // Daily-peak 5h-window utilization; one mid-period day hits the limit
+        // so the red bar and the peak note render in the demo.
+        let used_percent = if day_index == total_days / 2 {
+            100.0
+        } else {
+            rng.range(2, 65) as f64
+        };
+        collection.rate_limit_samples.push(RateLimitSample {
+            timestamp,
+            used_percent,
         });
         collection.session_touches.push(SessionTouch {
             timestamp,

--- a/src/model.rs
+++ b/src/model.rs
@@ -94,6 +94,9 @@ pub struct UsageEvent {
     pub model: Option<String>,
     pub source_kind: SourceKind,
     pub attribution_agent: Option<String>,
+    /// Skill active when this message was produced (Claude `attributionSkill`).
+    /// Feeds the SKILLS section only — never the share card.
+    pub attribution_skill: Option<String>,
     /// Repository / working-directory label derived from the log location
     /// (Claude: project directory name; Codex: `session_meta` cwd).
     pub project: Option<String>,
@@ -126,6 +129,32 @@ pub struct DurationEvent {
     pub session_id: Option<String>,
     pub duration_ms: u64,
     pub status: Option<String>,
+}
+
+/// One `rate_limits` snapshot from a Codex rollout: the plan's primary
+/// (5-hour) window utilization at that moment. History-only material — the
+/// dashboard shows past utilization, never a "current" meter.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RateLimitSample {
+    pub timestamp: OffsetDateTime,
+    pub used_percent: f64,
+}
+
+/// One Codex turn's reasoning-effort setting (`turn_context.payload.effort`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EffortEvent {
+    pub timestamp: Option<OffsetDateTime>,
+    pub effort: String,
+}
+
+/// Per-assistant-message mode flags for Claude: whether extended thinking
+/// fired (a `thinking` content block exists — block presence only, text is
+/// never read) and whether fast mode served it (`usage.speed == "fast"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModeEvent {
+    pub timestamp: Option<OffsetDateTime>,
+    pub has_thinking: bool,
+    pub fast: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -161,6 +190,9 @@ pub struct Collection {
     pub tool_events: Vec<ToolEvent>,
     pub session_touches: Vec<SessionTouch>,
     pub duration_events: Vec<DurationEvent>,
+    pub rate_limit_samples: Vec<RateLimitSample>,
+    pub effort_events: Vec<EffortEvent>,
+    pub mode_events: Vec<ModeEvent>,
     pub stats: ScanStats,
 }
 
@@ -173,6 +205,9 @@ impl Collection {
             tool_events: Vec::new(),
             session_touches: Vec::new(),
             duration_events: Vec::new(),
+            rate_limit_samples: Vec::new(),
+            effort_events: Vec::new(),
+            mode_events: Vec::new(),
             stats: ScanStats::default(),
         }
     }
@@ -192,6 +227,15 @@ impl Collection {
             combined
                 .duration_events
                 .extend(collection.duration_events.iter().cloned());
+            combined
+                .rate_limit_samples
+                .extend(collection.rate_limit_samples.iter().cloned());
+            combined
+                .effort_events
+                .extend(collection.effort_events.iter().cloned());
+            combined
+                .mode_events
+                .extend(collection.mode_events.iter().cloned());
             combined.stats.add_assign(&collection.stats);
         }
         combined.stats.usage_events = combined.usage_events.len();
@@ -247,6 +291,50 @@ pub struct AgentStat {
     pub name: String,
     pub usage: TokenUsage,
     pub calls: usize,
+}
+
+/// Per-skill token volume over the fixed 30-day window (Claude
+/// `attributionSkill`). TUI-only — must never reach the share card.
+#[derive(Debug, Clone)]
+pub struct SkillStat {
+    pub name: String,
+    pub usage: TokenUsage,
+}
+
+/// One day of the LIMITS history. `NoUse` = no provider activity that day;
+/// `NoSample` = activity but the CLI recorded no rate-limit snapshot (older
+/// versions); `Measured` = the day's peak `used_percent`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum LimitDay {
+    NoUse,
+    NoSample,
+    Measured(f64),
+}
+
+/// Daily-peak history of the plan's 5h window over the fixed 30-day window,
+/// oldest day first.
+#[derive(Debug, Clone)]
+pub struct LimitsHistory {
+    pub days: Vec<(Date, LimitDay)>,
+    pub peak: Option<(Date, f64)>,
+}
+
+/// Mode usage over the fixed 30-day window: how the user lets the model
+/// think. Claude: thinking-block fire rate (+ fast mode when used);
+/// Codex: reasoning-effort distribution.
+#[derive(Debug, Clone, Default)]
+pub struct ModesSummary {
+    pub assistant_turns: usize,
+    pub thinking_turns: usize,
+    pub fast_turns: usize,
+    /// (effort label, turns), sorted by turns descending.
+    pub efforts: Vec<(String, usize)>,
+}
+
+impl ModesSummary {
+    pub fn is_empty(&self) -> bool {
+        self.assistant_turns == 0 && self.efforts.is_empty()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -325,6 +413,12 @@ pub struct Summary {
     pub model_daily: Vec<ModelDailyStat>,
     pub models: Vec<ModelStat>,
     pub agents: Vec<AgentStat>,
+    /// Fixed 30-day window (same as the codename window), NOT the display
+    /// `--days` — attribution fields exist only in recent logs, so an
+    /// all-time cut would silently under-count.
+    pub skills: Vec<SkillStat>,
+    pub limits: Option<LimitsHistory>,
+    pub modes: ModesSummary,
     pub tools: Vec<ToolStat>,
     pub projects: Vec<ProjectStat>,
     pub sessions: usize,

--- a/src/share/fixtures.rs
+++ b/src/share/fixtures.rs
@@ -36,6 +36,9 @@ pub(crate) fn sample_summary() -> Summary {
             reported_cost_usd: None,
         }],
         agents: Vec::new(),
+        skills: Vec::new(),
+        limits: None,
+        modes: crate::model::ModesSummary::default(),
         tools: Vec::new(),
         projects: vec![
             crate::model::ProjectStat {

--- a/src/ui/charts.rs
+++ b/src/ui/charts.rs
@@ -3,7 +3,7 @@ use std::collections::BTreeMap;
 use ratatui::prelude::*;
 
 use crate::format::format_tokens;
-use crate::model::Summary;
+use crate::model::{LimitDay, Summary};
 
 use super::theme;
 use super::utils;
@@ -304,6 +304,114 @@ pub(super) fn model_chart_lines(
                     utils::month_abbrev(day.date.month()),
                     day.date.day()
                 ),
+            ))
+        })
+        .collect();
+    out.push(axis_label_row(width, &points));
+    out
+}
+
+/// LIMITS history: daily peak of the plan's 5h window as BY HOUR-style bars.
+/// The y-axis is FIXED at 0-100% (unlike the auto-scaled charts) so a quiet
+/// month doesn't inflate a 3% day into a full column. A day that hit the
+/// limit renders red; a day with no provider use renders as a faint dot; a
+/// day with use but no recorded sample stays blank.
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Chart geometry is display-only."
+)]
+pub(super) fn limits_chart_lines(
+    summary: &Summary,
+    width: u16,
+    body_height: usize,
+) -> Vec<Line<'static>> {
+    let Some(limits) = &summary.limits else {
+        return Vec::new();
+    };
+    if limits.days.is_empty() {
+        return Vec::new();
+    }
+    let height = body_height.max(1);
+    let half_cells = height * 2;
+    let day_count = limits.days.len();
+    let graph_available = usize::from(width).saturating_sub(7);
+    let chars_per_bar = if graph_available >= day_count * 2 {
+        2
+    } else {
+        1
+    };
+
+    let annotation = limits.peak.map_or_else(String::new, |(date, value)| {
+        format!(
+            "peak {value:.0}% · {} {}",
+            utils::month_abbrev(date.month()),
+            date.day()
+        )
+    });
+    let mut out = vec![utils::section_title("LIMITS", &annotation)];
+
+    let level_of = |day: &LimitDay| -> usize {
+        match day {
+            LimitDay::Measured(value) if *value > 0.0 => {
+                ((value / 100.0) * half_cells as f64).round().max(1.0) as usize
+            }
+            _ => 0,
+        }
+    };
+
+    for row in 0..height {
+        let label = match row {
+            0 => format!("{:>5}%", 100),
+            _ if row == height / 2 => format!("{:>5}%", 50),
+            _ if row == height - 1 => format!("{:>6}", 0),
+            _ => " ".repeat(6),
+        };
+        let mut spans = vec![
+            Span::styled(label, Style::default().fg(theme::MUTED)),
+            Span::styled("│", Style::default().fg(theme::DIM)),
+        ];
+        let half_bottom = 2 * (height - 1 - row);
+        let half_top = half_bottom + 1;
+        let baseline = row == height - 1;
+        for (_, day) in &limits.days {
+            let level = level_of(day);
+            let glyph = if level > half_top {
+                "█"
+            } else if level > half_bottom {
+                "▄"
+            } else if baseline {
+                match day {
+                    // Measured 0% is a real data point, not an absence.
+                    LimitDay::Measured(_) => "▁",
+                    LimitDay::NoUse => "·",
+                    LimitDay::NoSample => " ",
+                }
+            } else {
+                " "
+            };
+            let color = match day {
+                LimitDay::Measured(value) if *value >= 99.5 => theme::HOT,
+                LimitDay::Measured(_) => theme::GREEN,
+                _ => theme::DIM,
+            };
+            spans.push(Span::styled(
+                glyph.repeat(chars_per_bar),
+                Style::default().fg(color),
+            ));
+        }
+        out.push(Line::from(spans));
+    }
+
+    let points: Vec<(usize, String)> = [0.0, 0.5, 1.0]
+        .iter()
+        .filter_map(|fraction| {
+            let index = ((day_count.saturating_sub(1)) as f64 * fraction).round() as usize;
+            let (date, _) = limits.days.get(index)?;
+            Some((
+                7 + index * chars_per_bar,
+                format!("{} {}", utils::month_abbrev(date.month()), date.day()),
             ))
         })
         .collect();

--- a/src/ui/page.rs
+++ b/src/ui/page.rs
@@ -1,6 +1,6 @@
 use ratatui::prelude::*;
 
-use crate::model::Summary;
+use crate::model::{Provider, Summary};
 
 use super::activity;
 use super::badge;
@@ -18,6 +18,10 @@ const TWO_COLUMN_MIN_WIDTH: u16 = 80;
 /// The whole dashboard body as one flowing list of lines. Charts and the
 /// two-column section area are rendered into lines (not widgets) so the
 /// entire page scrolls as a unit.
+#[allow(
+    clippy::too_many_lines,
+    reason = "Flat assembly of the page in decided section order; splitting adds indirection without logic."
+)]
 pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
     const CHART_BODY: usize = 6;
 
@@ -75,6 +79,32 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
         lines.push(Line::default());
     }
 
+    // LIMITS history lives in the chart band on the Codex tab only — the
+    // rate-limit data is Codex-specific and deliberately historical (no
+    // "current" meter; this dashboard looks back, it doesn't monitor).
+    if summary.provider == Provider::Codex {
+        let chart_width = if two_column { left_u16 } else { width };
+        let limits = charts::limits_chart_lines(summary, chart_width, CHART_BODY);
+        if !limits.is_empty() {
+            lines.extend(limits);
+            lines.push(Line::default());
+        }
+    }
+
+    // Per-tab v0.9 sections: SKILLS is Claude-only (attribution is a Claude
+    // log feature), MODES renders each provider's own dial. The Total tab
+    // shows neither — they are not cross-provider metrics.
+    let skills = if summary.provider == Provider::Claude {
+        sections::skill_lines(summary, if two_column { left_u16 } else { width }, 6)
+    } else {
+        Vec::new()
+    };
+    let modes = if matches!(summary.provider, Provider::Claude | Provider::Codex) {
+        sections::modes_lines(summary, if two_column { right_u16 } else { width })
+    } else {
+        Vec::new()
+    };
+
     // Decided chart priority: activity → token/day → by-hour → completion →
     // PARALLEL AGENTS → models → (cost/signal/projects/tools/agents).
     if width < TWO_COLUMN_MIN_WIDTH {
@@ -89,6 +119,10 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
         }
         lines.extend(sections::model_lines(summary, width));
         lines.push(Line::default());
+        if !skills.is_empty() {
+            lines.extend(skills);
+            lines.push(Line::default());
+        }
         lines.extend(sections::cost_lines(summary, width));
         lines.push(Line::default());
         lines.extend(sections::signal_lines(summary, width));
@@ -99,6 +133,10 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
         if !summary.agents.is_empty() {
             lines.push(Line::default());
             lines.extend(sections::agent_lines(summary, width, 4));
+        }
+        if !modes.is_empty() {
+            lines.push(Line::default());
+            lines.extend(modes);
         }
         return lines;
     }
@@ -118,18 +156,25 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
     }
 
     // Pair sections column-wise so each row of sections starts on the same
-    // line in both columns: MODELS|COST, PROJECTS|SIGNAL, TOOLS|SUBAGENTS.
-    let left_blocks = [
-        sections::model_lines(summary, left_u16),
-        sections::project_lines(summary, left_u16),
-        sections::tool_lines(summary, left_u16, 10),
-    ];
+    // line in both columns: MODELS|COST, (SKILLS), PROJECTS|SIGNAL,
+    // TOOLS|SUBAGENTS, (·|MODES). SKILLS slots directly under MODELS on the
+    // Claude tab; MODES closes the right column as a deliberately small
+    // section.
+    let mut left_blocks = vec![sections::model_lines(summary, left_u16)];
+    if !skills.is_empty() {
+        left_blocks.push(skills);
+    }
+    left_blocks.push(sections::project_lines(summary, left_u16));
+    left_blocks.push(sections::tool_lines(summary, left_u16, 10));
     let mut right_blocks = vec![
         sections::cost_lines(summary, right_u16),
         sections::signal_lines(summary, right_u16),
     ];
     if !summary.agents.is_empty() {
         right_blocks.push(sections::agent_lines(summary, right_u16, 5));
+    }
+    if !modes.is_empty() {
+        right_blocks.push(modes);
     }
 
     lines.extend(join_section_columns(
@@ -256,5 +301,136 @@ fn ops_color(ops: &str) -> Color {
         "Luna" => theme::BLUE,
         "Eclipse" => theme::PURPLE,
         _ => theme::MUTED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use time::macros::date;
+
+    use super::*;
+    use crate::model::{LimitDay, LimitsHistory, ModesSummary, SkillStat, TokenUsage};
+    use crate::share::fixtures::sample_summary;
+
+    fn rendered(summary: &Summary, width: u16) -> String {
+        page_lines(summary, width)
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn v09_summary(provider: Provider) -> Summary {
+        let mut summary = sample_summary();
+        summary.provider = provider;
+        summary.skills = vec![SkillStat {
+            name: "sk:review".to_owned(),
+            usage: TokenUsage {
+                input_tokens: 1_000_000,
+                ..TokenUsage::default()
+            },
+        }];
+        summary.limits = Some(LimitsHistory {
+            days: vec![
+                (date!(2026 - 06 - 10), LimitDay::NoUse),
+                (date!(2026 - 06 - 11), LimitDay::Measured(100.0)),
+                (date!(2026 - 06 - 12), LimitDay::NoSample),
+            ],
+            peak: Some((date!(2026 - 06 - 11), 100.0)),
+        });
+        summary.modes = ModesSummary {
+            assistant_turns: 100,
+            thinking_turns: 49,
+            fast_turns: 0,
+            efforts: vec![("xhigh".to_owned(), 93), ("low".to_owned(), 6)],
+        };
+        summary
+    }
+
+    /// SKILLS renders on the Claude tab only; LIMITS on the Codex tab only;
+    /// MODES on each provider tab; the Total tab shows none of them even when
+    /// the combined summary carries the data.
+    #[test]
+    fn v09_sections_render_on_their_own_tabs_only() {
+        let claude = rendered(&v09_summary(Provider::Claude), 110);
+        assert!(claude.contains("SKILLS"));
+        assert!(claude.contains("attributed"));
+        assert!(claude.contains("MODES"));
+        assert!(claude.contains("thinking"));
+        assert!(!claude.contains("LIMITS"));
+
+        let codex = rendered(&v09_summary(Provider::Codex), 110);
+        assert!(codex.contains("LIMITS"));
+        assert!(codex.contains("peak 100%"));
+        assert!(codex.contains("MODES"));
+        assert!(codex.contains("xhigh"));
+        assert!(!codex.contains("SKILLS"));
+
+        let total = rendered(&v09_summary(Provider::Combined), 110);
+        assert!(!total.contains("SKILLS"));
+        assert!(!total.contains("LIMITS"));
+        assert!(!total.contains("MODES"));
+    }
+
+    /// Narrow terminals stack the sections; the per-tab rules still hold.
+    #[test]
+    fn v09_sections_render_in_narrow_layout() {
+        let claude = rendered(&v09_summary(Provider::Claude), 60);
+        assert!(claude.contains("SKILLS"));
+        assert!(claude.contains("MODES"));
+
+        let codex = rendered(&v09_summary(Provider::Codex), 60);
+        assert!(codex.contains("LIMITS"));
+        assert!(!codex.contains("SKILLS"));
+    }
+
+    /// The demo (`AGENT_WALKER_DEMO=1`) must actually exercise the new
+    /// sections end-to-end: synthetic collections through the real analyzer
+    /// through the real page renderer. Guards against demo fixtures that
+    /// compile but never fire (e.g. a skill pick rate that rounds to zero).
+    #[test]
+    fn demo_report_renders_v09_sections() {
+        let config = crate::app::Config {
+            demo: true,
+            claude_dir: std::path::PathBuf::new(),
+            codex_dir: std::path::PathBuf::new(),
+            agy_dir: None,
+            opencode_dir: None,
+            cursor: None,
+            days: 30,
+            use_cache: false,
+            local_offset: time::UtcOffset::UTC,
+        };
+        let report = crate::demo::demo_report(&config);
+
+        let claude = report
+            .providers
+            .iter()
+            .find(|summary| summary.provider == Provider::Claude)
+            .expect("demo should have a Claude provider");
+        let claude_page = rendered(claude, 110);
+        assert!(claude_page.contains("SKILLS"));
+        assert!(claude_page.contains("attributed"));
+        assert!(claude_page.contains("thinking"));
+
+        let codex = report
+            .providers
+            .iter()
+            .find(|summary| summary.provider == Provider::Codex)
+            .expect("demo should have a Codex provider");
+        let codex_page = rendered(codex, 110);
+        assert!(codex_page.contains("LIMITS"));
+        assert!(codex_page.contains("peak 100%"));
+        assert!(codex_page.contains("xhigh"));
+
+        let total_page = rendered(&report.combined, 110);
+        assert!(!total_page.contains("SKILLS"));
+        assert!(!total_page.contains("LIMITS"));
+        assert!(!total_page.contains("MODES"));
     }
 }

--- a/src/ui/sections.rs
+++ b/src/ui/sections.rs
@@ -527,3 +527,141 @@ pub(super) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'static>
     }
     lines
 }
+
+/// SKILLS: token volume by Claude `attributionSkill` over the fixed 30-day
+/// window (the display `--days` does not apply — attribution fields exist
+/// only in recent logs). Claude-tab only, TUI-only: skill names are
+/// personal-environment labels that must never reach the share card, so this
+/// section reads `summary.skills`, never the `models` path the card renders.
+/// Share is of ATTRIBUTED volume; the subtitle carries the honest denominator.
+pub(super) fn skill_lines(summary: &Summary, width: u16, limit: usize) -> Vec<Line<'static>> {
+    if summary.skills.is_empty() {
+        return Vec::new();
+    }
+    let attributed = summary.skills.iter().fold(0_u64, |sum, skill| {
+        sum.saturating_add(skill.usage.token_volume())
+    });
+    let subtitle = if summary.recent_window_volume > 0 {
+        format!(
+            "30d · attributed {} of volume",
+            format_percent(attributed, summary.recent_window_volume)
+        )
+    } else {
+        "30d".to_owned()
+    };
+    let max_volume = summary
+        .skills
+        .first()
+        .map_or(0, |skill| skill.usage.token_volume());
+    let bar_width = usize::from(width).saturating_sub(31).clamp(8, 24);
+
+    let mut lines = vec![utils::section_title("SKILLS", &subtitle)];
+    for skill in summary.skills.iter().take(limit) {
+        let volume = skill.usage.token_volume();
+        let filled = utils::bar_fill(volume, max_volume, bar_width);
+        lines.push(Line::from(vec![
+            Span::styled(
+                format!("{:<14}", utils::compact_label(&skill.name, 13)),
+                Style::default().fg(theme::TEXT),
+            ),
+            Span::styled("▄".repeat(filled), Style::default().fg(theme::ACCENT)),
+            Span::styled(
+                "▄".repeat(bar_width - filled),
+                Style::default().fg(theme::FAINT),
+            ),
+            Span::styled(
+                format!(" {:>8}", format_tokens(volume)),
+                Style::default()
+                    .fg(theme::TEXT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("{:>7}", format_percent(volume, attributed)),
+                Style::default().fg(theme::MUTED),
+            ),
+        ]));
+    }
+    lines
+}
+
+/// MODES: how the model is allowed to think, per provider dial — Claude
+/// shows the thinking fire rate (plus fast mode once it has data), Codex the
+/// reasoning-effort mix. Deliberately small (a couple of rows): the dials are
+/// asymmetric across providers, so each tab renders only its own rows.
+pub(super) fn modes_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
+    let modes = &summary.modes;
+    if modes.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = vec![utils::section_title("MODES", "30d")];
+    let bar_width = usize::from(width).saturating_sub(30).clamp(6, 16);
+
+    if modes.assistant_turns > 0 {
+        let thinking = u64::try_from(modes.thinking_turns).unwrap_or(0);
+        let turns = u64::try_from(modes.assistant_turns).unwrap_or(1).max(1);
+        let filled = utils::bar_fill(thinking, turns, bar_width);
+        lines.push(Line::from(vec![
+            Span::styled("thinking  ", Style::default().fg(theme::TEXT)),
+            Span::styled("█".repeat(filled), Style::default().fg(theme::PURPLE)),
+            Span::styled(
+                "█".repeat(bar_width - filled),
+                Style::default().fg(theme::FAINT),
+            ),
+            Span::styled(
+                format!(" {:>6}", format_percent(thinking, turns)),
+                Style::default()
+                    .fg(theme::TEXT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" of turns", Style::default().fg(theme::MUTED)),
+        ]));
+    }
+
+    if modes.fast_turns > 0 && modes.assistant_turns > 0 {
+        let fast = u64::try_from(modes.fast_turns).unwrap_or(0);
+        let turns = u64::try_from(modes.assistant_turns).unwrap_or(1).max(1);
+        let filled = utils::bar_fill(fast, turns, bar_width);
+        lines.push(Line::from(vec![
+            Span::styled("fast      ", Style::default().fg(theme::TEXT)),
+            Span::styled("█".repeat(filled), Style::default().fg(theme::GOLD)),
+            Span::styled(
+                "█".repeat(bar_width - filled),
+                Style::default().fg(theme::FAINT),
+            ),
+            Span::styled(
+                format!(" {:>6}", format_percent(fast, turns)),
+                Style::default()
+                    .fg(theme::TEXT)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" of turns", Style::default().fg(theme::MUTED)),
+        ]));
+    }
+
+    if !modes.efforts.is_empty() {
+        let total: usize = modes.efforts.iter().map(|(_, count)| count).sum();
+        let total = u64::try_from(total).unwrap_or(1).max(1);
+        let mut spans = vec![Span::styled("effort    ", Style::default().fg(theme::TEXT))];
+        for (index, (label, count)) in modes.efforts.iter().take(3).enumerate() {
+            if index > 0 {
+                spans.push(Span::styled(" · ", Style::default().fg(theme::DIM)));
+            }
+            let style = if index == 0 {
+                Style::default()
+                    .fg(theme::TEXT)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::MUTED)
+            };
+            spans.push(Span::styled(
+                format!(
+                    "{label} {}",
+                    format_percent(u64::try_from(*count).unwrap_or(0), total)
+                ),
+                style,
+            ));
+        }
+        lines.push(Line::from(spans));
+    }
+    lines
+}


### PR DESCRIPTION
## Summary

Agent CLIs now write fields their older versions didn't. This PR turns three of them into dashboard sections — all cut on the fixed 30-day codename window, all TUI-only (the share card is untouched), all historical by design: this dashboard looks back, it doesn't monitor.

## Why

- Claude Code recently started attributing messages to the active skill (`attributionSkill`); Codex rollouts now carry `rate_limits` snapshots and per-turn reasoning `effort`. None of this was surfaced anywhere.
- A live rate-limit meter was considered and rejected: the value is in *how close you've been running to the plan's window*, not the current number. Hence a daily-peak history instead of a gauge.
- Attribution only exists in recent logs, so the window is pinned to 30 days — an all-time cut would silently under-count.

## Changes

- **SKILLS** (Claude tab): per-skill token ranking. Shares are of *attributed* volume; the subtitle carries the honest denominator ("attributed N% of volume").
- **LIMITS** (Codex tab): daily peak of the 5h-window utilization, BY HOUR-style chart with a fixed 0–100% axis, red bars on limit-hit days, and tri-state days (no-use `·` / no-sample blank / measured 0% `▁`).
- **MODES** (per provider tab): Claude = thinking fire rate (content-block presence only — the text is never read) plus fast mode once it has data; Codex = reasoning-effort mix. Each tab renders only its own dial; Total renders none.
- **Dedup fix**: keyed usage duplicates now merge metadata with fill/OR semantics — a streaming fragment carrying the attribution no longer loses it to the larger-volume line. `CACHE_VERSION` 8 → 9.
- **Pricing**: `codex-auto-review` (no LiteLLM key) prices as the Codex default model; snapshot tests pin `claude-fable-5` / `claude-opus-4-8` / `gpt-5.5`.
- Housekeeping: stale `--agy-dir` help text fixed (tokens are decoded from the conversation store since v0.7); local agent notes (`AGENTS.md`/`CLAUDE.md`) added to `.gitignore`.

No release with this PR — the version stays 0.8.0 and the changes sit under `[Unreleased]` in the CHANGELOG.

## Test

- `cargo fmt` / `cargo clippy --all-targets` (pedantic, 0 warnings) / `cargo test` — 102 passed.
- New tests: skill attribution + mode-event parsing, duplicate-line metadata fill/OR, Codex effort + rate-limit sampling (secondary window explicitly ignored), 30-day window boundaries + tri-state LIMITS days + peak, per-tab render exclusivity (SKILLS=Claude only, LIMITS=Codex only, Total=none) in wide and narrow layouts, and an end-to-end `AGENT_WALKER_DEMO=1` render assertion through the real analyzer + renderer.
- Real-log run: `--snapshot --no-cache` over 2,532 files / 490k lines, `parse_errors: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)