### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-07-08
 
 Three new views of how you drive your agents, all cut on the fixed 30-day
 window and all TUI-only — the share card is untouched.
@@ -255,6 +255,7 @@ First public release with the codename system and the shareable stats card.
 
 Initial npm packaging.
 
+[0.9.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.9.0
 [0.8.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.8.0
 [0.7.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.7.0
 [0.6.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.6.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-walker"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-walker"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Local AI coding-agent usage dashboard — tokens, cost, projects, autonomy."


### PR DESCRIPTION
Release commit for v0.9.0 — SKILLS / LIMITS / MODES (merged in #27).

- `Cargo.toml` 0.8.0 → 0.9.0 (+ `Cargo.lock`)
- CHANGELOG: `[Unreleased]` → `[0.9.0] - 2026-07-08` + link definition

After merge: annotated tag `v0.9.0` on main HEAD → cargo-dist takes over (5-target build, GitHub Release, npm publish).

🤖 Generated with [Claude Code](https://claude.com/claude-code)