### PR TITLE
Claude: count fallback/advisor calls hidden in usage.iterations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Claude: a second model's API call inside one turn — `fallback_message`
+  when the selected model fails mid-turn, `advisor_message` in advisor
+  setups — is logged only inside `usage.iterations` and was silently
+  dropped, losing that call's tokens and attributing the whole turn to the
+  winning model. Iterations beyond the top-level mirror now surface as
+  their own usage events under their own model.
+
 ## [0.10.1] - 2026-07-21
 
 ### Fixed
@@ -282,6 +293,7 @@ First public release with the codename system and the shareable stats card.
 Initial npm packaging.
 
 [#36]: https://github.com/miiiiiiich/agent-walker/issues/36
+[Unreleased]: https://github.com/miiiiiiich/agent-walker/compare/v0.10.1...HEAD
 [0.10.1]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.1
 [0.10.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.0
 [0.9.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Claude: a second model's API call inside one turn — `fallback_message`
-  when the selected model fails mid-turn, `advisor_message` in advisor
-  setups — is logged only inside `usage.iterations` and was silently
-  dropped, losing that call's tokens and attributing the whole turn to the
-  winning model. Iterations beyond the top-level mirror now surface as
-  their own usage events under their own model.
+- Claude: advisor calls (`advisor_message` inside `usage.iterations`) are
+  billed under their own model but absent from the top-level counters, and
+  were silently dropped. They now surface as their own usage events.
+  Failed fallback attempts stay excluded by design — the top level is the
+  turn's billed usage for the serving model, and a failed attempt is not
+  billed.
 
 ## [0.10.1] - 2026-07-21
 

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -267,8 +267,7 @@ fn parse_line(
     let usage_value = message.get("usage").or_else(|| value.get("usage"));
     let message_id = string_field(message, "id");
     let top_model = string_field(message, "model").or_else(|| string_field(value, "model"));
-    let top_usage = parse_usage(usage_value);
-    if let Some(usage) = top_usage.clone() {
+    if let Some(usage) = parse_usage(usage_value) {
         events.usage_events.push(KeyedUsageEvent {
             key: message_id.as_ref().map(|id| format!("message:{id}")),
             event: UsageEvent {
@@ -285,34 +284,27 @@ fn parse_line(
         });
     }
 
-    // A second model's API call — `fallback_message` when the selected model
-    // fails mid-turn, `advisor_message` in advisor setups — is logged ONLY
-    // inside `usage.iterations` (added to the log schema 2026-04); the top
-    // level carries the winning call alone. Skipping the array silently drops
-    // the other model's real consumption and attributes the whole turn to the
-    // winner. Exactly one iteration mirrors the top-level numbers (the winning
-    // call itself, its `model` sometimes omitted): skip that single mirror and
-    // emit the rest as their own events, keyed per iteration index so
-    // streaming duplicates of the message still dedupe.
+    // `usage.iterations` (log-schema addition, 2026-04) breaks one turn into
+    // its underlying API calls. The top level is the turn's BILLED usage for
+    // the serving model: a failed fallback attempt is not billed (fallback
+    // credit refunds the switch) and the turn is billed as the serving model
+    // alone, and on advisor turns the top level already sums the main-model
+    // iterations. So main-model `message` and `fallback_message` entries must
+    // never be re-emitted — only `advisor_message` entries are additional
+    // billed calls, made under their own model and absent from the top-level
+    // counters (ccusage#1115 lost them entirely). Keyed per iteration index
+    // so streamed duplicates of the message still dedupe.
     if let Some(iterations) = usage_value
         .and_then(|usage| usage.get("iterations"))
         .and_then(Value::as_array)
     {
-        let mut mirror_skipped = false;
         for (index, iteration) in iterations.iter().enumerate() {
+            if string_field(iteration, "type").as_deref() != Some("advisor_message") {
+                continue;
+            }
             let Some(usage) = parse_usage(Some(iteration)) else {
                 continue;
             };
-            let model = string_field(iteration, "model");
-            let is_mirror = !mirror_skipped
-                && top_usage
-                    .as_ref()
-                    .is_some_and(|top| same_call_counters(top, &usage))
-                && (model.is_none() || model == top_model);
-            if is_mirror {
-                mirror_skipped = true;
-                continue;
-            }
             events.usage_events.push(KeyedUsageEvent {
                 key: message_id
                     .as_ref()
@@ -320,7 +312,7 @@ fn parse_line(
                 event: UsageEvent {
                     timestamp,
                     session_id: session_id.clone(),
-                    model: model.or_else(|| top_model.clone()),
+                    model: string_field(iteration, "model").or_else(|| top_model.clone()),
                     source_kind: event_source_kind,
                     attribution_agent: attribution_agent.clone(),
                     attribution_skill: attribution_skill.clone(),
@@ -420,17 +412,6 @@ fn collect_tool_events(
             },
         });
     }
-}
-
-/// Same API call? Compared on the four externally-billed counters only — the
-/// top-level usage additionally carries `server_tool_use` (and may differ in
-/// the ephemeral split), which its mirror iteration omits, so full-struct
-/// equality would miss the mirror and double-count every message.
-fn same_call_counters(a: &TokenUsage, b: &TokenUsage) -> bool {
-    a.input_tokens == b.input_tokens
-        && a.output_tokens == b.output_tokens
-        && a.cache_creation_input_tokens == b.cache_creation_input_tokens
-        && a.cache_read_input_tokens == b.cache_read_input_tokens
 }
 
 fn parse_usage(value: Option<&Value>) -> Option<TokenUsage> {
@@ -554,16 +535,14 @@ mod tests {
         );
     }
 
-    /// A model-fallback turn logs the failed call ONLY inside
-    /// `usage.iterations` (the top level carries the winning call): the extra
-    /// iteration must surface as its own usage event under its own model,
-    /// while the mirror of the top-level call must not double-count. A
-    /// streamed duplicate of the message dedupes per iteration index.
+    /// A mid-turn model fallback: the failed attempt in `usage.iterations`
+    /// is NOT billed (the turn is billed as the serving model, mirrored at
+    /// the top level), so exactly one event must come out — the top-level
+    /// serving call. A streamed duplicate still dedupes.
     #[test]
-    fn fallback_iteration_usage_is_counted_once() {
+    fn fallback_attempt_is_not_counted() {
         let temp = TempDir::new().expect("test tempdir should be created");
-        let line = r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","message":{"id":"m1","model":"claude-opus-4-8","usage":{"input_tokens":2,"output_tokens":2156,"cache_creation_input_tokens":0,"cache_read_input_tokens":313782,"iterations":[{"type":"message","model":"claude-fable-5","input_tokens":2,"output_tokens":601,"cache_creation_input_tokens":991,"cache_read_input_tokens":495675,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":991}},{"type":"fallback_message","model":"claude-opus-4-8","input_tokens":2,"output_tokens":2156,"cache_creation_input_tokens":0,"cache_read_input_tokens":313782}]},"content":[{"type":"text","text":"hi"}]}}"#;
-        // The same message streamed twice — keyed dedup must hold per event.
+        let line = r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","message":{"id":"m1","model":"claude-opus-4-8","usage":{"input_tokens":2,"output_tokens":2156,"cache_creation_input_tokens":0,"cache_read_input_tokens":313782,"iterations":[{"type":"message","model":"claude-fable-5","input_tokens":2,"output_tokens":601,"cache_creation_input_tokens":991,"cache_read_input_tokens":495675},{"type":"fallback_message","model":"claude-opus-4-8","input_tokens":2,"output_tokens":2156,"cache_creation_input_tokens":0,"cache_read_input_tokens":313782}]},"content":[{"type":"text","text":"hi"}]}}"#;
         fs::write(
             temp.path().join("session.jsonl"),
             format!("{line}\n{line}\n"),
@@ -572,26 +551,50 @@ mod tests {
 
         let collection = collect(temp.path(), None, false, UtcOffset::UTC);
 
-        // Top-level (winning) call + the failed fable-5 attempt; the
-        // fallback_message iteration mirrors the top level and is skipped.
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(
+            collection.usage_events[0].model.as_deref(),
+            Some("claude-opus-4-8")
+        );
+        assert_eq!(
+            collection.usage_events[0].usage.token_volume(),
+            2 + 2156 + 313_782
+        );
+    }
+
+    /// An advisor turn (ccusage#1115 shape): the top level sums the
+    /// main-model iterations, while the `advisor_message` in between is an
+    /// additional billed call under its own model, absent from the top-level
+    /// counters — it must surface as its own event, and the main-model
+    /// iterations must not be re-emitted.
+    #[test]
+    fn advisor_iteration_is_counted_under_its_own_model() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","message":{"id":"m1","model":"claude-sonnet-5","usage":{"input_tokens":22,"output_tokens":12,"cache_creation_input_tokens":0,"cache_read_input_tokens":220,"iterations":[{"type":"message","model":"claude-sonnet-5","input_tokens":10,"output_tokens":5,"cache_creation_input_tokens":0,"cache_read_input_tokens":100},{"type":"advisor_message","model":"claude-opus-4-8","input_tokens":3,"output_tokens":9,"cache_creation_input_tokens":0,"cache_read_input_tokens":50},{"type":"message","model":"claude-sonnet-5","input_tokens":12,"output_tokens":7,"cache_creation_input_tokens":0,"cache_read_input_tokens":120}]},"content":[{"type":"text","text":"hi"}]}}"#,
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
         assert_eq!(collection.usage_events.len(), 2);
-        let top = collection
+        let advisor = collection
             .usage_events
             .iter()
             .find(|event| event.model.as_deref() == Some("claude-opus-4-8"))
-            .expect("winning call should be counted");
-        assert_eq!(top.usage.token_volume(), 2 + 2156 + 313_782);
-        let attempt = collection
+            .expect("advisor call should be counted");
+        assert_eq!(advisor.usage.token_volume(), 3 + 9 + 50);
+        let main = collection
             .usage_events
             .iter()
-            .find(|event| event.model.as_deref() == Some("claude-fable-5"))
-            .expect("failed attempt should be counted");
-        assert_eq!(attempt.usage.token_volume(), 2 + 601 + 991 + 495_675);
-        assert_eq!(attempt.usage.cache_creation_ephemeral_1h_input_tokens, 991);
+            .find(|event| event.model.as_deref() == Some("claude-sonnet-5"))
+            .expect("main turn should be counted once");
+        assert_eq!(main.usage.token_volume(), 22 + 12 + 220);
     }
 
-    /// The ordinary shape — one iteration mirroring the top-level numbers
-    /// with its `model` omitted — must not create a second event.
+    /// The ordinary shape — one main-model `message` iteration mirroring the
+    /// top-level numbers — must not create a second event.
     #[test]
     fn single_mirror_iteration_adds_nothing() {
         let temp = TempDir::new().expect("test tempdir should be created");

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -264,22 +264,72 @@ fn parse_line(
 
     collect_mode_event(value, message, timestamp, events);
 
-    if let Some(usage) = parse_usage(message.get("usage").or_else(|| value.get("usage"))) {
-        let model = string_field(message, "model").or_else(|| string_field(value, "model"));
+    let usage_value = message.get("usage").or_else(|| value.get("usage"));
+    let message_id = string_field(message, "id");
+    let top_model = string_field(message, "model").or_else(|| string_field(value, "model"));
+    let top_usage = parse_usage(usage_value);
+    if let Some(usage) = top_usage.clone() {
         events.usage_events.push(KeyedUsageEvent {
-            key: string_field(message, "id").map(|message_id| format!("message:{message_id}")),
+            key: message_id.as_ref().map(|id| format!("message:{id}")),
             event: UsageEvent {
                 timestamp,
                 session_id: session_id.clone(),
-                model,
+                model: top_model.clone(),
                 source_kind: event_source_kind,
                 attribution_agent: attribution_agent.clone(),
-                attribution_skill,
+                attribution_skill: attribution_skill.clone(),
                 project: project.map(ToOwned::to_owned),
                 usage,
                 reported_cost_usd: None,
             },
         });
+    }
+
+    // A second model's API call — `fallback_message` when the selected model
+    // fails mid-turn, `advisor_message` in advisor setups — is logged ONLY
+    // inside `usage.iterations` (added to the log schema 2026-04); the top
+    // level carries the winning call alone. Skipping the array silently drops
+    // the other model's real consumption and attributes the whole turn to the
+    // winner. Exactly one iteration mirrors the top-level numbers (the winning
+    // call itself, its `model` sometimes omitted): skip that single mirror and
+    // emit the rest as their own events, keyed per iteration index so
+    // streaming duplicates of the message still dedupe.
+    if let Some(iterations) = usage_value
+        .and_then(|usage| usage.get("iterations"))
+        .and_then(Value::as_array)
+    {
+        let mut mirror_skipped = false;
+        for (index, iteration) in iterations.iter().enumerate() {
+            let Some(usage) = parse_usage(Some(iteration)) else {
+                continue;
+            };
+            let model = string_field(iteration, "model");
+            let is_mirror = !mirror_skipped
+                && top_usage
+                    .as_ref()
+                    .is_some_and(|top| same_call_counters(top, &usage))
+                && (model.is_none() || model == top_model);
+            if is_mirror {
+                mirror_skipped = true;
+                continue;
+            }
+            events.usage_events.push(KeyedUsageEvent {
+                key: message_id
+                    .as_ref()
+                    .map(|id| format!("message:{id}:iter:{index}")),
+                event: UsageEvent {
+                    timestamp,
+                    session_id: session_id.clone(),
+                    model: model.or_else(|| top_model.clone()),
+                    source_kind: event_source_kind,
+                    attribution_agent: attribution_agent.clone(),
+                    attribution_skill: attribution_skill.clone(),
+                    project: project.map(ToOwned::to_owned),
+                    usage,
+                    reported_cost_usd: None,
+                },
+            });
+        }
     }
 
     collect_tool_events(
@@ -370,6 +420,17 @@ fn collect_tool_events(
             },
         });
     }
+}
+
+/// Same API call? Compared on the four externally-billed counters only — the
+/// top-level usage additionally carries `server_tool_use` (and may differ in
+/// the ephemeral split), which its mirror iteration omits, so full-struct
+/// equality would miss the mirror and double-count every message.
+fn same_call_counters(a: &TokenUsage, b: &TokenUsage) -> bool {
+    a.input_tokens == b.input_tokens
+        && a.output_tokens == b.output_tokens
+        && a.cache_creation_input_tokens == b.cache_creation_input_tokens
+        && a.cache_read_input_tokens == b.cache_read_input_tokens
 }
 
 fn parse_usage(value: Option<&Value>) -> Option<TokenUsage> {
@@ -491,6 +552,59 @@ mod tests {
             collection.tool_events[0].subagent_type.as_deref(),
             Some("Explore")
         );
+    }
+
+    /// A model-fallback turn logs the failed call ONLY inside
+    /// `usage.iterations` (the top level carries the winning call): the extra
+    /// iteration must surface as its own usage event under its own model,
+    /// while the mirror of the top-level call must not double-count. A
+    /// streamed duplicate of the message dedupes per iteration index.
+    #[test]
+    fn fallback_iteration_usage_is_counted_once() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        let line = r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","message":{"id":"m1","model":"claude-opus-4-8","usage":{"input_tokens":2,"output_tokens":2156,"cache_creation_input_tokens":0,"cache_read_input_tokens":313782,"iterations":[{"type":"message","model":"claude-fable-5","input_tokens":2,"output_tokens":601,"cache_creation_input_tokens":991,"cache_read_input_tokens":495675,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":991}},{"type":"fallback_message","model":"claude-opus-4-8","input_tokens":2,"output_tokens":2156,"cache_creation_input_tokens":0,"cache_read_input_tokens":313782}]},"content":[{"type":"text","text":"hi"}]}}"#;
+        // The same message streamed twice — keyed dedup must hold per event.
+        fs::write(
+            temp.path().join("session.jsonl"),
+            format!("{line}\n{line}\n"),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        // Top-level (winning) call + the failed fable-5 attempt; the
+        // fallback_message iteration mirrors the top level and is skipped.
+        assert_eq!(collection.usage_events.len(), 2);
+        let top = collection
+            .usage_events
+            .iter()
+            .find(|event| event.model.as_deref() == Some("claude-opus-4-8"))
+            .expect("winning call should be counted");
+        assert_eq!(top.usage.token_volume(), 2 + 2156 + 313_782);
+        let attempt = collection
+            .usage_events
+            .iter()
+            .find(|event| event.model.as_deref() == Some("claude-fable-5"))
+            .expect("failed attempt should be counted");
+        assert_eq!(attempt.usage.token_volume(), 2 + 601 + 991 + 495_675);
+        assert_eq!(attempt.usage.cache_creation_ephemeral_1h_input_tokens, 991);
+    }
+
+    /// The ordinary shape — one iteration mirroring the top-level numbers
+    /// with its `model` omitted — must not create a second event.
+    #[test]
+    fn single_mirror_iteration_adds_nothing() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            r#"{"timestamp":"2026-06-01T00:00:00Z","sessionId":"s1","type":"assistant","message":{"id":"m1","model":"claude-fable-5","usage":{"input_tokens":10,"output_tokens":3,"cache_creation_input_tokens":20,"cache_read_input_tokens":30,"iterations":[{"type":"message","input_tokens":10,"output_tokens":3,"cache_creation_input_tokens":20,"cache_read_input_tokens":30}]},"content":[{"type":"text","text":"hi"}]}}"#,
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.usage_events[0].usage.token_volume(), 63);
     }
 
     #[test]

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -33,9 +33,11 @@ use crate::model::{
 ///   effort / mode event lists on `FileEvents`.
 /// - 10: Codex dedup keys became content-based (fork-replay dedup, GH-36) —
 ///   same layout, but cached events carry the old positional keys.
+/// - 11: Claude `usage.iterations` parsing (fallback/advisor calls) — cached
+///   `FileEvents` lack the iteration events.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
-const CACHE_VERSION: u32 = 10;
+const CACHE_VERSION: u32 = 11;
 
 /// Normalize a working-directory path into a project label: strip the home
 /// prefix and (on Windows) normalize separators to `/` so the same repo


### PR DESCRIPTION
Claude Code breaks one turn into its underlying API calls in `usage.iterations` (log-schema addition, 2026-04). Advisor calls (`advisor_message`) are billed under their own model but absent from the top-level counters, so they were silently dropped — ccusage hit the same loss (ryoppippi/ccusage#1115). Failed fallback attempts also appear in the array but are NOT billed (the turn is billed as the serving model, which the top level mirrors), so they must stay excluded.

## Fix

- Emit `advisor_message` iterations as their own usage events (`message:{id}:iter:{n}`, own model, keyed so streamed duplicates dedupe).
- `message` / `fallback_message` entries are never re-emitted: on advisor turns the top level already sums the main-model iterations, and a failed fallback attempt is unbilled.
- `CACHE_VERSION` 10 → 11 so the fix reaches cached installs.

## Verification

fmt / clippy (pedantic, zero warnings) / 117 tests incl. advisor (sum-shaped top level), fallback-exclusion, and mirror fixtures. Real data: the corpus's actual fallback turn counts exactly the top-level serving-model usage; full-corpus A/B byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)