### PR TITLE
Copilot: new provider — GitHub Copilot CLI session logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   double-count nor fall out of the analysis window. Sessions that never exit
   cleanly contribute activity but no tokens until they close — see
   docs/copilot.md for the full contract. Dotted model spellings
-  (`claude-sonnet-4.6`) now resolve against dashed pricing keys.
+  (`claude-sonnet-4.6`) now resolve against dashed pricing keys. The tab
+  also carries a Copilot-only CREDITS panel — daily AI-credit spend rebuilt
+  from the cumulative nano-AIU ledger, which keeps tracking even for
+  sessions that never exit cleanly — and COMPLETION turn durations from the
+  CLI's explicit turn boundaries.
 
 ## [0.10.1] - 2026-07-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,16 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turn's billed usage for the serving model, and a failed attempt is not
   billed.
 
-## [Unreleased]
-
 ### Added
 
 - GitHub Copilot CLI support: a new auto-detected provider tab reading
   `~/.copilot/session-state/*/events.jsonl` (override with `--copilot-dir` /
-  `COPILOT_HOME`). Tokens come from the per-model cumulative totals the CLI
-  writes on clean exit; resumed sessions never double-count. Sessions that
-  never exit cleanly contribute activity but no tokens until they close —
-  see docs/copilot.md for the full contract.
+  `COPILOT_HOME`). Tokens come from the per-model totals the CLI writes on
+  clean exit, counted as deltas between exits so resumed sessions neither
+  double-count nor fall out of the analysis window. Sessions that never exit
+  cleanly contribute activity but no tokens until they close — see
+  docs/copilot.md for the full contract. Dotted model spellings
+  (`claude-sonnet-4.6`) now resolve against dashed pricing keys.
 
 ## [0.10.1] - 2026-07-21
 
@@ -304,7 +304,6 @@ First public release with the codename system and the shareable stats card.
 Initial npm packaging.
 
 [#36]: https://github.com/miiiiiiich/agent-walker/issues/36
-[Unreleased]: https://github.com/miiiiiiich/agent-walker/compare/v0.10.1...HEAD
 [Unreleased]: https://github.com/miiiiiiich/agent-walker/compare/v0.10.1...HEAD
 [0.10.1]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.1
 [0.10.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   turn's billed usage for the serving model, and a failed attempt is not
   billed.
 
+## [Unreleased]
+
+### Added
+
+- GitHub Copilot CLI support: a new auto-detected provider tab reading
+  `~/.copilot/session-state/*/events.jsonl` (override with `--copilot-dir` /
+  `COPILOT_HOME`). Tokens come from the per-model cumulative totals the CLI
+  writes on clean exit; resumed sessions never double-count. Sessions that
+  never exit cleanly contribute activity but no tokens until they close —
+  see docs/copilot.md for the full contract.
+
 ## [0.10.1] - 2026-07-21
 
 ### Fixed
@@ -293,6 +304,7 @@ First public release with the codename system and the shareable stats card.
 Initial npm packaging.
 
 [#36]: https://github.com/miiiiiiich/agent-walker/issues/36
+[Unreleased]: https://github.com/miiiiiiich/agent-walker/compare/v0.10.1...HEAD
 [Unreleased]: https://github.com/miiiiiiich/agent-walker/compare/v0.10.1...HEAD
 [0.10.1]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.1
 [0.10.0]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.0

--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,7 @@ bunx agent-walker
 | `--share <path>` | カードを PNG 出力＋キャプション表示して終了 |
 | `--no-cache` | パースキャッシュを無視して全再走査 |
 | `--no-cursor` | Cursor コレクタを無効化。Cursor はマシン外に資格情報（Cursor のセッション cookie を cursor.com へ）を送る唯一のコレクタなので、これを付けるとネットワークリクエストを一切行わない |
-| `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` | 非標準のログ場所を指定（`CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `OPENCODE_HOME` も自動で読む） |
+| `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` / `--copilot-dir` | 非標準のログ場所を指定（`CLAUDE_CONFIG_DIR` / `CODEX_HOME` / `OPENCODE_HOME` / `COPILOT_HOME` も自動で読む） |
 | `--cursor-state-db` | 非標準の Cursor `state.vscdb` を指定（または `CURSOR_TOKEN` でセッショントークンを直接渡す） |
 | `--completions <shell>` | シェル補完を出力して終了 |
 
@@ -85,6 +85,7 @@ bunx agent-walker
 | **[Claude Code](docs/claude.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **[Codex CLI](docs/codex.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **[OpenCode](docs/opencode.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **[GitHub Copilot CLI](docs/copilot.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **[Cursor](docs/cursor.md)** | ✅ | ✅ | — | — | ✅ |
 | **[Antigravity](docs/agy.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Flags:
 | `--share <path>` | Render the stats card to a PNG, print its caption, and exit |
 | `--no-cache` | Rescan every log file, ignoring the parse cache |
 | `--no-cursor` | Disable the Cursor collector — the only one that sends a credential off the machine (your Cursor session cookie, to cursor.com) — so it makes no network request |
-| `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` | Point at non-standard log locations (also honors `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, and `OPENCODE_HOME` when set) |
+| `--claude-dir` / `--codex-dir` / `--agy-dir` / `--opencode-dir` / `--copilot-dir` | Point at non-standard log locations (also honors `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `OPENCODE_HOME`, and `COPILOT_HOME` when set) |
 | `--cursor-state-db` | Point at a non-standard Cursor `state.vscdb` (or set `CURSOR_TOKEN` to supply the session token directly) |
 | `--completions <shell>` | Print shell completions (e.g. `--completions zsh`) and exit |
 
@@ -115,6 +115,7 @@ Every agent is auto-detected — install nothing, configure nothing, just run it
 | **[Claude Code](docs/claude.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **[Codex CLI](docs/codex.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **[OpenCode](docs/opencode.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
+| **[GitHub Copilot CLI](docs/copilot.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **[Cursor](docs/cursor.md)** | ✅ | ✅ | — | — | ✅ |
 | **[Antigravity](docs/agy.md)** | ✅ | ✅ | ✅ | ✅ | ✅ |
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -1,0 +1,47 @@
+# GitHub Copilot CLI
+
+## Where the data comes from
+
+`~/.copilot/session-state/<uuid>/events.jsonl` — one directory per session,
+written by the agentic GitHub Copilot CLI (`@github/copilot`; not the retired
+`gh copilot` extension). The root is overridable with `COPILOT_HOME` or
+`--copilot-dir`. Auto-detected: the Copilot tab appears only when session logs
+exist. Everything is read locally; nothing leaves the machine.
+
+## What's captured
+
+- **Token usage** from the `session.shutdown` event the CLI appends on clean
+  exit (`/exit`, or a non-interactive run completing). It carries per-model
+  cumulative totals for the whole session
+  (`inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens` /
+  `reasoningTokens`), mapped to the same schema as the other providers:
+
+  ```
+  tokens = (input − cache_read) + output + cache_read + cache_write
+  ```
+
+  `inputTokens` includes the cached reads (verified against the CLI's own
+  on-screen totals), so fresh input is the difference — the same convention
+  as Codex. `reasoningTokens` is a subset of `outputTokens` and is tracked
+  without being double-added.
+
+- **Model** per entry in `modelMetrics` (e.g. `gpt-5-mini`,
+  `claude-sonnet-4.6`).
+- **Project** from the session's working directory (`session.start`).
+- **Tools** from `tool.execution_start` events, deduplicated by tool-call id.
+- **Activity** from every timestamped event in the session stream.
+
+## Caveats
+
+- **Sessions that never exit cleanly have no token data.** The CLI writes
+  token totals only at shutdown; a crashed or still-open session contributes
+  activity but no tokens. The gap closes when the session eventually exits —
+  the cumulative shutdown covers its whole lifetime.
+- **Resumed sessions**: `--resume` appends to the same session, and each
+  later clean exit appends another shutdown with cumulative totals. Only the
+  latest totals count (never summed), keyed per session and model.
+- **Long-lived sessions** attribute all their tokens to the day of the first
+  clean exit — day-level granularity is only as fine as your exit habits.
+- The CLI's AI-credit accounting (`totalNanoAiu`, premium requests) is not
+  surfaced; agent-walker reports token volume and API-equivalent cost like
+  every other tab.

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -29,6 +29,14 @@ exist. Everything is read locally; nothing leaves the machine.
 
 - **Model** per entry in `modelMetrics` (e.g. `gpt-5-mini`,
   `claude-sonnet-4.6`).
+- **AI credits** (the CREDITS panel, Copilot tab only): daily spend history
+  from the cumulative `totalNanoAiu` ledger (1 credit = 1e9 nano-AIU),
+  carried on periodic usage checkpoints as well as shutdowns — so credits
+  keep tracking even for sessions that never exit cleanly, complementing the
+  token gap below. Historical by design: a ledger of spend that already
+  happened, never a remaining-quota meter.
+- **Turn durations** from explicit `assistant.turn_start` / `turn_end`
+  pairs (no heuristics — Copilot logs real turn boundaries).
 - **Project** from the session's working directory (`session.start`).
 - **Tools** from `tool.execution_start` events, deduplicated by tool-call id.
 - **Activity** from every timestamped event in the session stream.
@@ -37,8 +45,8 @@ exist. Everything is read locally; nothing leaves the machine.
 
 - **Sessions that never exit cleanly have no token data.** The CLI writes
   token totals only at shutdown; a crashed or still-open session contributes
-  activity but no tokens. The gap closes when the session eventually exits —
-  the cumulative shutdown covers its whole lifetime.
+  activity and credits, but no tokens. The gap closes when the session
+  eventually exits — the cumulative shutdown covers its whole lifetime.
 - **Resumed sessions**: `--resume` appends to the same session, and each
   later clean exit appends another shutdown with cumulative totals. Every
   exit contributes only what happened since the previous one — cumulatives
@@ -46,6 +54,5 @@ exist. Everything is read locally; nothing leaves the machine.
   epoch counted in full.
 - **Day-level granularity is only as fine as your exit habits**: everything
   between two clean exits lands on the later exit's day.
-- The CLI's AI-credit accounting (`totalNanoAiu`, premium requests) is not
-  surfaced; agent-walker reports token volume and API-equivalent cost like
-  every other tab.
+- Premium-request counts are not surfaced; tokens, API-equivalent cost, and
+  the credit ledger are.

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -14,7 +14,9 @@ exist. Everything is read locally; nothing leaves the machine.
   exit (`/exit`, or a non-interactive run completing). It carries per-model
   cumulative totals for the whole session
   (`inputTokens` / `outputTokens` / `cacheReadTokens` / `cacheWriteTokens` /
-  `reasoningTokens`), mapped to the same schema as the other providers:
+  `reasoningTokens`). Each shutdown is counted as the delta since the previous
+  one, dated at its own exit time, and mapped to the same schema as the other
+  providers:
 
   ```
   tokens = (input − cache_read) + output + cache_read + cache_write
@@ -38,10 +40,12 @@ exist. Everything is read locally; nothing leaves the machine.
   activity but no tokens. The gap closes when the session eventually exits —
   the cumulative shutdown covers its whole lifetime.
 - **Resumed sessions**: `--resume` appends to the same session, and each
-  later clean exit appends another shutdown with cumulative totals. Only the
-  latest totals count (never summed), keyed per session and model.
-- **Long-lived sessions** attribute all their tokens to the day of the first
-  clean exit — day-level granularity is only as fine as your exit habits.
+  later clean exit appends another shutdown with cumulative totals. Every
+  exit contributes only what happened since the previous one — cumulatives
+  are never summed, and a counter going backwards (CLI update) starts a new
+  epoch counted in full.
+- **Day-level granularity is only as fine as your exit habits**: everything
+  between two clean exits lands on the later exit's day.
 - The CLI's AI-credit accounting (`totalNanoAiu`, premium requests) is not
   surfaced; agent-walker reports token volume and API-equivalent cost like
   every other tab.

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -9,8 +9,8 @@ use std::collections::BTreeMap;
 use time::{Date, Duration, OffsetDateTime, UtcOffset};
 
 use crate::model::{
-    Collection, DailySessions, DailyStat, LimitDay, LimitsHistory, ModelDailyStat, ModesSummary,
-    SkillStat, Summary, TokenUsage, ToolStat,
+    Collection, CreditsHistory, DailySessions, DailyStat, LimitDay, LimitsHistory, ModelDailyStat,
+    ModesSummary, SkillStat, Summary, TokenUsage, ToolStat,
 };
 
 use self::aggregates::Aggregates;
@@ -202,6 +202,7 @@ pub fn summarize(
         local_offset,
         &recent_active_days,
     );
+    let credits = credits_history(collection, codename_window_start, period_end, local_offset);
     let mode_usage = modes_summary(collection, codename_window_start, period_end, local_offset);
     let recent_window_active_days = recent_active_days.len();
 
@@ -222,6 +223,7 @@ pub fn summarize(
         agents,
         skills,
         limits,
+        credits,
         modes: mode_usage,
         tools,
         projects,
@@ -321,6 +323,53 @@ fn limits_history(
         date += Duration::days(1);
     }
     Some(LimitsHistory { days, peak })
+}
+
+/// Daily AI-credit spend over the fixed 30-day window: the sum of Copilot's
+/// `totalNanoAiu` deltas per local day, in credits (1e9 nano-AIU). `None`
+/// when the provider records no credit samples at all.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "Credits are a display quantity; nano-AIU never approaches 2^52."
+)]
+fn credits_history(
+    collection: &Collection,
+    window_start: Date,
+    period_end: Date,
+    local_offset: UtcOffset,
+) -> Option<CreditsHistory> {
+    let mut daily: BTreeMap<Date, u64> = BTreeMap::new();
+    for sample in &collection.credit_samples {
+        let date = sample.timestamp.to_offset(local_offset).date();
+        if date < window_start || date > period_end {
+            continue;
+        }
+        let entry = daily.entry(date).or_insert(0);
+        *entry = entry.saturating_add(sample.nano_aiu);
+    }
+    if daily.is_empty() {
+        return None;
+    }
+
+    let mut days = Vec::new();
+    let mut total_nano = 0u64;
+    let mut peak: Option<(Date, f64)> = None;
+    let mut date = window_start;
+    while date <= period_end {
+        let nano = daily.get(&date).copied().unwrap_or(0);
+        total_nano = total_nano.saturating_add(nano);
+        let credits = nano as f64 / 1e9;
+        if nano > 0 && peak.is_none_or(|(_, best)| credits > best) {
+            peak = Some((date, credits));
+        }
+        days.push((date, credits));
+        date += Duration::days(1);
+    }
+    Some(CreditsHistory {
+        days,
+        total: total_nano as f64 / 1e9,
+        peak,
+    })
 }
 
 /// Mode usage over the fixed 30-day window: Claude thinking / fast flags per
@@ -458,6 +507,7 @@ mod tests {
             ],
             duration_events: Vec::new(),
             rate_limit_samples: Vec::new(),
+            credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             stats: ScanStats::default(),
@@ -514,6 +564,7 @@ mod tests {
             session_touches: Vec::new(),
             duration_events: Vec::new(),
             rate_limit_samples: Vec::new(),
+            credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             stats: ScanStats::default(),
@@ -560,6 +611,7 @@ mod tests {
             session_touches: Vec::new(),
             duration_events: Vec::new(),
             rate_limit_samples: Vec::new(),
+            credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             stats: ScanStats::default(),
@@ -641,6 +693,7 @@ mod v09_tests {
             tool_events: Vec::new(),
             session_touches: Vec::new(),
             duration_events: Vec::new(),
+            credit_samples: Vec::new(),
             rate_limit_samples: vec![
                 RateLimitSample {
                     timestamp: datetime!(2026-06-22 08:00 UTC),

--- a/src/analyzer/concurrency.rs
+++ b/src/analyzer/concurrency.rs
@@ -133,6 +133,7 @@ mod tests {
             session_touches: touches,
             duration_events: Vec::new(),
             rate_limit_samples: Vec::new(),
+            credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             stats: ScanStats::default(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -493,6 +493,7 @@ mod tests {
             agents: Vec::new(),
             skills: Vec::new(),
             limits: None,
+            credits: None,
             modes: crate::model::ModesSummary::default(),
             tools: Vec::new(),
             projects: Vec::new(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -247,14 +247,18 @@ pub fn load_report(config: &Config) -> Result<AppSummary> {
 }
 
 /// A provider earns a tab only if it has real activity. Token volume catches
-/// most agents; sessions, tools, and completions are the fallback for a session
-/// that logged activity but no usage tokens. Everything false ⇒ the directory
-/// was missing or empty, so the tab is dropped instead of showing a blank tab.
+/// most agents; sessions, tools, completions, and the fixed-window credit
+/// ledger are the fallback for a session that logged activity but no usage
+/// tokens (Copilot credits cut on the fixed 30-day window, so they can exist
+/// even when a short `--days` display window is empty). Everything false ⇒
+/// the directory was missing or empty, so the tab is dropped instead of
+/// showing a blank tab.
 fn provider_has_data(summary: &crate::model::Summary) -> bool {
     summary.total_usage.token_volume() > 0
         || summary.sessions > 0
         || !summary.tools.is_empty()
         || summary.completion_duration.is_some()
+        || summary.credits.is_some()
 }
 
 /// Order the provider tabs by how much each is used — token volume, descending —

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,7 +8,7 @@ use clap_complete::Shell;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::analyzer::summarize;
-use crate::collector::{agy, claude, codex, cursor, opencode};
+use crate::collector::{agy, claude, codex, copilot, cursor, opencode};
 use crate::format::snapshot_app;
 use crate::model::{AppSummary, Collection};
 use crate::ui;
@@ -37,6 +37,13 @@ pub struct Args {
     /// feeds the token totals like every other provider.
     #[arg(long, value_name = "DIR")]
     pub agy_dir: Option<PathBuf>,
+
+    /// Override the GitHub Copilot CLI root (default `~/.copilot`, or
+    /// `$COPILOT_HOME`). Auto-detected: its tab appears only when
+    /// `session-state` session logs are present. Token totals come from the
+    /// per-session shutdown records the CLI writes on clean exit.
+    #[arg(long, value_name = "DIR")]
+    pub copilot_dir: Option<PathBuf>,
 
     /// Override the OpenCode data directory (default `~/.local/share/opencode`,
     /// or `$OPENCODE_HOME` / `$XDG_DATA_HOME/opencode`). Auto-detected: its tab
@@ -106,6 +113,10 @@ pub struct Config {
     /// rather than fatal, since Antigravity is optional — its tab only shows up
     /// when logs are actually found there.
     pub agy_dir: Option<PathBuf>,
+    /// GitHub Copilot CLI root, or `None` when it can't be resolved. Optional
+    /// and auto-detected like Antigravity: the tab appears only when session
+    /// logs exist under `session-state/`.
+    pub copilot_dir: Option<PathBuf>,
     /// OpenCode data directory, or `None` when it can't be resolved. Optional and
     /// auto-detected like Antigravity: the tab appears only when `opencode.db`
     /// exists there.
@@ -175,6 +186,9 @@ pub fn run(args: Args) -> Result<()> {
         // without a home dir should still start and just omit the agy tab.
         agy_dir: args.agy_dir.or_else(|| default_agy_dir().ok()),
         // Same treatment as agy: auto-detected, resolution failure swallowed.
+        copilot_dir: args
+            .copilot_dir
+            .or_else(|| crate::paths::copilot_home().ok()),
         opencode_dir: args.opencode_dir.or_else(|| default_opencode_dir().ok()),
         // Cursor is auto-detected (a signed-in state.vscdb) but is the one
         // collector that reaches the network; `None` when signed out / disabled.
@@ -274,58 +288,71 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
         .max(u64::try_from(crate::codename::CODENAME_WINDOW_DAYS).unwrap_or(30) + 1);
     let mtime_floor = SystemTime::now().checked_sub(StdDuration::from_secs(history_days * 86_400));
 
-    let (codex_result, agy_result, opencode_result, cursor_result, claude_collection) =
-        std::thread::scope(|scope| {
-            let codex_handle = scope.spawn(|| {
-                codex::collect(
-                    &config.codex_dir,
-                    mtime_floor,
-                    config.use_cache,
-                    config.local_offset,
-                )
-            });
-            // Cursor is auto-detected (disable with --no-cursor) and the only
-            // collector that hits the network, so it runs in its own thread
-            // alongside the local ones.
-            let cursor_handle = scope.spawn(|| {
-                config.cursor.as_ref().map(|cursor| {
-                    cursor::collect(
-                        &cursor.state_db,
-                        &cursor.cli_config,
-                        cursor.token.as_deref(),
-                        mtime_floor,
-                        config.local_offset,
-                    )
-                })
-            });
-            // Antigravity and OpenCode are probed whenever their directory
-            // resolved; the collector returns an empty collection for a missing
-            // dir / DB, and an empty provider is filtered out before it ever
-            // becomes a tab.
-            let agy_handle = scope.spawn(|| {
-                config.agy_dir.as_ref().map(|dir| {
-                    agy::collect(dir, mtime_floor, config.use_cache, config.local_offset)
-                })
-            });
-            let opencode_handle = scope.spawn(|| {
-                config.opencode_dir.as_ref().map(|dir| {
-                    opencode::collect(dir, mtime_floor, config.use_cache, config.local_offset)
-                })
-            });
-            let claude_collection = claude::collect(
-                &config.claude_dir,
+    let (
+        codex_result,
+        agy_result,
+        opencode_result,
+        copilot_result,
+        cursor_result,
+        claude_collection,
+    ) = std::thread::scope(|scope| {
+        let codex_handle = scope.spawn(|| {
+            codex::collect(
+                &config.codex_dir,
                 mtime_floor,
                 config.use_cache,
                 config.local_offset,
-            );
-            (
-                codex_handle.join(),
-                agy_handle.join(),
-                opencode_handle.join(),
-                cursor_handle.join(),
-                claude_collection,
             )
         });
+        // Cursor is auto-detected (disable with --no-cursor) and the only
+        // collector that hits the network, so it runs in its own thread
+        // alongside the local ones.
+        let cursor_handle = scope.spawn(|| {
+            config.cursor.as_ref().map(|cursor| {
+                cursor::collect(
+                    &cursor.state_db,
+                    &cursor.cli_config,
+                    cursor.token.as_deref(),
+                    mtime_floor,
+                    config.local_offset,
+                )
+            })
+        });
+        // Antigravity and OpenCode are probed whenever their directory
+        // resolved; the collector returns an empty collection for a missing
+        // dir / DB, and an empty provider is filtered out before it ever
+        // becomes a tab.
+        let agy_handle = scope.spawn(|| {
+            config
+                .agy_dir
+                .as_ref()
+                .map(|dir| agy::collect(dir, mtime_floor, config.use_cache, config.local_offset))
+        });
+        let opencode_handle = scope.spawn(|| {
+            config.opencode_dir.as_ref().map(|dir| {
+                opencode::collect(dir, mtime_floor, config.use_cache, config.local_offset)
+            })
+        });
+        let copilot_handle = scope.spawn(|| {
+            config.copilot_dir.as_ref().map(|dir| {
+                copilot::collect(dir, mtime_floor, config.use_cache, config.local_offset)
+            })
+        });
+        let claude_collection = claude::collect(
+            &config.claude_dir,
+            mtime_floor,
+            config.use_cache,
+            config.local_offset,
+        );
+        (
+            codex_handle.join(),
+            agy_handle.join(),
+            opencode_handle.join(),
+            copilot_handle.join(),
+            cursor_handle.join(),
+            claude_collection,
+        )
+    });
 
     let mut collections = vec![
         claude_collection,
@@ -336,6 +363,9 @@ fn load_report_inner(config: &Config) -> Result<AppSummary> {
     }
     if let Some(oc) = opencode_result.map_err(|_| anyhow!("OpenCode collector thread panicked"))? {
         collections.push(oc);
+    }
+    if let Some(cp) = copilot_result.map_err(|_| anyhow!("Copilot collector thread panicked"))? {
+        collections.push(cp);
     }
     if let Some(cursor) = cursor_result.map_err(|_| anyhow!("Cursor collector thread panicked"))? {
         collections.push(cursor);

--- a/src/collector/copilot.rs
+++ b/src/collector/copilot.rs
@@ -52,26 +52,36 @@ pub fn collect(
     // for the extension: the session directory also holds `files/` snapshots
     // of workspace content, which may themselves be .jsonl.
     let mut files: Vec<PathBuf> = Vec::new();
-    if let Ok(entries) = std::fs::read_dir(&sessions) {
-        for entry in entries.flatten() {
-            let path = entry.path().join("events.jsonl");
-            let meta = match std::fs::metadata(&path) {
-                Ok(meta) => meta,
-                // Absent is the normal case (not every session dir has an
-                // event stream); anything else is a real read failure worth
-                // surfacing in the stats line.
-                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
-                Err(_) => {
+    match std::fs::read_dir(&sessions) {
+        Err(_) => {
+            // An unopenable session-state must not read as "no Copilot data".
+            collection.stats.unreadable_dirs += 1;
+        }
+        Ok(entries) => {
+            for entry in entries {
+                let Ok(entry) = entry else {
                     collection.stats.unreadable_files += 1;
                     continue;
+                };
+                let path = entry.path().join("events.jsonl");
+                let meta = match std::fs::metadata(&path) {
+                    Ok(meta) => meta,
+                    // Absent is the normal case (not every session dir has an
+                    // event stream); anything else is a real read failure
+                    // worth surfacing in the stats line.
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(_) => {
+                        collection.stats.unreadable_files += 1;
+                        continue;
+                    }
+                };
+                if let (Some(floor), Ok(mtime)) = (mtime_floor, meta.modified())
+                    && mtime < floor
+                {
+                    continue;
                 }
-            };
-            if let (Some(floor), Ok(mtime)) = (mtime_floor, meta.modified())
-                && mtime < floor
-            {
-                continue;
+                files.push(path);
             }
-            files.push(path);
         }
     }
     if files.is_empty() {
@@ -256,6 +266,13 @@ fn collect_shutdown_usage(
     shutdown_index: usize,
     events: &mut FileEvents,
 ) {
+    // A shutdown the analyzer cannot place in time must not advance the
+    // baseline either — otherwise the usage up to it would be subtracted by
+    // the NEXT valid shutdown and lost forever, instead of being recovered
+    // there in full.
+    if timestamp.is_none() {
+        return;
+    }
     let Some(metrics) = value
         .get("data")
         .and_then(|data| data.get("modelMetrics"))
@@ -267,6 +284,16 @@ fn collect_shutdown_usage(
         let Some(usage) = entry.get("usage") else {
             continue;
         };
+        // A syntactically valid but incomplete usage object would read as
+        // all-zero counters, masquerade as an epoch reset, and poison the
+        // baseline (1000 → missing → 1100 would count 1000 + 1100). Require
+        // the two core counters to be present before trusting the snapshot;
+        // a genuine zero (cache-write-only) still carries the fields.
+        if usage.get("inputTokens").and_then(Value::as_u64).is_none()
+            || usage.get("outputTokens").and_then(Value::as_u64).is_none()
+        {
+            continue;
+        }
         let current = RawCounters {
             input: u64_field(usage, "inputTokens"),
             output: u64_field(usage, "outputTokens"),
@@ -671,6 +698,59 @@ mod tests {
             .map(|sample| sample.nano_aiu)
             .collect();
         assert_eq!(deltas, vec![1_000_000_000, 2_500_000_000, 500_000_000]);
+    }
+
+    /// A shutdown without a timestamp cannot be placed in a period — it must
+    /// not advance the cumulative baseline, so the next valid exit recovers
+    /// the full amount instead of losing everything before the bad record.
+    #[test]
+    fn shutdown_without_timestamp_does_not_advance_baseline() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.shutdown","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T13:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.usage_events[0].usage.token_volume(), 1_100);
+        assert!(collection.usage_events[0].timestamp.is_some());
+    }
+
+    /// An incomplete usage object (missing counters) must not masquerade as
+    /// an epoch reset and poison the baseline: 1000 → missing → 1100 counts
+    /// 1000 + 100, never 1000 + 1100.
+    #[test]
+    fn incomplete_snapshot_does_not_poison_the_baseline() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:30:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{}}}}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T13:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1100,"outputTokens":110,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        let total: u64 = collection
+            .usage_events
+            .iter()
+            .map(|event| event.usage.token_volume())
+            .sum();
+        assert_eq!(total, 1_100 + 110);
     }
 
     /// The nano-AIU ledger resetting (decrease) starts a new epoch counted

--- a/src/collector/copilot.rs
+++ b/src/collector/copilot.rs
@@ -1,0 +1,361 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+use serde_json::Value;
+use time::format_description::well_known::Rfc3339;
+use time::{OffsetDateTime, UtcOffset};
+
+use crate::collector::{
+    FileEvents, KeyedToolEvent, KeyedUsageEvent, merge_into, parse_files_cached, project_from_cwd,
+};
+use crate::model::{
+    Collection, Provider, SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
+};
+
+/// GitHub Copilot CLI (`@github/copilot`, the agentic CLI — not the retired
+/// `gh copilot` extension) writes one directory per session under
+/// `<root>/session-state/<uuid>/`, with an `events.jsonl` event stream.
+/// Schema verified live against CLI 1.0.73:
+///
+/// - Token counts exist ONLY on `session.shutdown`, written on clean exit
+///   (`/exit` or non-interactive completion) as per-model cumulative totals
+///   (`data.modelMetrics`). A crashed or still-open session has no shutdown
+///   and therefore no token data — a documented gap, recovered when the
+///   session eventually exits (the cumulative shutdown covers its lifetime).
+/// - Resuming appends to the SAME session file and a later clean exit appends
+///   ANOTHER shutdown whose totals are cumulative, so per (session, model)
+///   only the last shutdown may count. `merge_into`'s larger-volume-wins rule
+///   on the `copilot:{session}:{model}` key does exactly that.
+pub fn collect(
+    root: &Path,
+    mtime_floor: Option<SystemTime>,
+    use_cache: bool,
+    local_offset: UtcOffset,
+) -> Collection {
+    let mut collection = Collection::new(Provider::Copilot, root.to_path_buf());
+    let sessions = root.join("session-state");
+    if !sessions.exists() {
+        return collection;
+    }
+
+    // Enumerate `<session dir>/events.jsonl` explicitly instead of globbing
+    // for the extension: the session directory also holds `files/` snapshots
+    // of workspace content, which may themselves be .jsonl.
+    let mut files: Vec<PathBuf> = Vec::new();
+    if let Ok(entries) = std::fs::read_dir(&sessions) {
+        for entry in entries.flatten() {
+            let path = entry.path().join("events.jsonl");
+            let Ok(meta) = std::fs::metadata(&path) else {
+                continue;
+            };
+            if let (Some(floor), Ok(mtime)) = (mtime_floor, meta.modified())
+                && mtime < floor
+            {
+                continue;
+            }
+            files.push(path);
+        }
+    }
+    if files.is_empty() {
+        return collection;
+    }
+    files.sort();
+
+    let per_file = parse_files_cached(
+        use_cache.then_some("copilot"),
+        &files,
+        local_offset,
+        |path| parse_file(path, local_offset),
+    );
+    merge_into(&mut collection, per_file);
+    collection
+}
+
+fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
+    let file = File::open(path).ok()?;
+    // The directory name is the session id (also carried in session.start).
+    let session_id = path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .map(ToOwned::to_owned);
+    let mut events = FileEvents::default();
+    let mut project: Option<String> = None;
+    let reader = BufReader::new(file);
+
+    for line in reader.lines() {
+        events.lines_seen += 1;
+        let Ok(line) = line else {
+            events.parse_errors += 1;
+            continue;
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            events.parse_errors += 1;
+            continue;
+        };
+
+        let timestamp = value
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(|raw| OffsetDateTime::parse(raw, &Rfc3339).ok());
+        if let (Some(timestamp), Some(session_id)) = (timestamp, session_id.as_ref()) {
+            events.session_touches.push(SessionTouch {
+                timestamp,
+                session_id: session_id.clone(),
+            });
+        }
+
+        match value.get("type").and_then(Value::as_str) {
+            Some("session.start") => {
+                if let Some(cwd) = value
+                    .get("data")
+                    .and_then(|data| data.get("context"))
+                    .and_then(|context| context.get("cwd"))
+                    .and_then(Value::as_str)
+                {
+                    project = Some(project_from_cwd(cwd));
+                }
+            }
+            Some("tool.execution_start") => {
+                collect_tool_event(&value, timestamp, session_id.as_ref(), &mut events);
+            }
+            Some("session.shutdown") => {
+                collect_shutdown_usage(
+                    &value,
+                    timestamp,
+                    session_id.as_ref(),
+                    project.as_deref(),
+                    &mut events,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    events.compress_touches(local_offset);
+    Some(events)
+}
+
+/// Per-model cumulative usage from a `session.shutdown`. Field semantics
+/// verified against the CLI's own on-screen totals: `inputTokens` INCLUDES
+/// `cacheReadTokens` (14,166 = 12,630 fresh + 1,536 cached in the probe
+/// session), so fresh input is the difference — the same convention as
+/// Codex. `reasoningTokens` is a subset of `outputTokens` and is tracked
+/// without being added to the volume.
+fn collect_shutdown_usage(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    project: Option<&str>,
+    events: &mut FileEvents,
+) {
+    let Some(metrics) = value
+        .get("data")
+        .and_then(|data| data.get("modelMetrics"))
+        .and_then(Value::as_object)
+    else {
+        return;
+    };
+    for (model, entry) in metrics {
+        let Some(usage) = entry.get("usage") else {
+            continue;
+        };
+        let input_tokens = u64_field(usage, "inputTokens");
+        let output_tokens = u64_field(usage, "outputTokens");
+        let cache_read = u64_field(usage, "cacheReadTokens");
+        if input_tokens == 0 && output_tokens == 0 {
+            continue;
+        }
+        events.usage_events.push(KeyedUsageEvent {
+            key: session_id.map(|sid| format!("copilot:{sid}:{model}")),
+            event: UsageEvent {
+                timestamp,
+                session_id: session_id.cloned(),
+                model: Some(model.clone()),
+                source_kind: SourceKind::Main,
+                attribution_agent: None,
+                attribution_skill: None,
+                project: project.map(ToOwned::to_owned),
+                usage: TokenUsage {
+                    input_tokens: input_tokens.saturating_sub(cache_read),
+                    output_tokens,
+                    reasoning_output_tokens: u64_field(usage, "reasoningTokens"),
+                    cache_read_input_tokens: cache_read,
+                    cache_creation_input_tokens: u64_field(usage, "cacheWriteTokens"),
+                    ..TokenUsage::default()
+                },
+                reported_cost_usd: None,
+            },
+        });
+    }
+}
+
+fn collect_tool_event(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    events: &mut FileEvents,
+) {
+    let Some(data) = value.get("data") else {
+        return;
+    };
+    let Some(tool_name) = data.get("toolName").and_then(Value::as_str) else {
+        return;
+    };
+    let key = data
+        .get("toolCallId")
+        .and_then(Value::as_str)
+        .map(|id| format!("copilot-tool:{id}"));
+    events.tool_events.push(KeyedToolEvent {
+        key,
+        event: ToolEvent {
+            timestamp,
+            session_id: session_id.cloned(),
+            tool_name: tool_name.to_owned(),
+            subagent_type: None,
+            source_kind: SourceKind::Main,
+        },
+    });
+}
+
+/// Token counts are untrusted log data; clamp to a generous sanity bound so
+/// downstream sums of a handful of fields can never overflow u64.
+fn u64_field(value: &Value, key: &str) -> u64 {
+    const MAX_SANE_TOKENS: u64 = 1 << 50;
+    value
+        .get(key)
+        .and_then(Value::as_u64)
+        .unwrap_or(0)
+        .min(MAX_SANE_TOKENS)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn write_session(root: &Path, session: &str, lines: &str) {
+        let dir = root.join("session-state").join(session);
+        fs::create_dir_all(&dir).expect("test dirs should be created");
+        fs::write(dir.join("events.jsonl"), lines).expect("fixture should be written");
+    }
+
+    #[test]
+    fn collects_shutdown_usage_tools_and_project() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.start","timestamp":"2026-07-27T12:40:52.292Z","data":{"sessionId":"s1","copilotVersion":"1.0.73","context":{"cwd":"/Users/me/code/app"}}}"#,
+                "\n",
+                r#"{"type":"tool.execution_start","timestamp":"2026-07-27T12:41:00.000Z","data":{"toolCallId":"call_1","toolName":"web_fetch","model":"gpt-5-mini"}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:41:08.275Z","data":{"shutdownType":"routine","modelMetrics":{"gpt-5-mini":{"requests":{"count":1,"cost":0},"usage":{"inputTokens":14166,"outputTokens":150,"cacheReadTokens":1536,"cacheWriteTokens":0,"reasoningTokens":128}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 1);
+        let event = &collection.usage_events[0];
+        assert_eq!(event.model.as_deref(), Some("gpt-5-mini"));
+        // inputTokens includes cacheReadTokens: fresh = 14,166 - 1,536.
+        assert_eq!(event.usage.input_tokens, 12_630);
+        assert_eq!(event.usage.cache_read_input_tokens, 1_536);
+        assert_eq!(event.usage.token_volume(), 14_166 + 150);
+        assert_eq!(event.usage.reasoning_output_tokens, 128);
+        // `/Users/me` is not this machine's home, so only the leading slash
+        // is trimmed — home stripping is covered by project_from_cwd tests.
+        assert_eq!(event.project.as_deref(), Some("Users/me/code/app"));
+        assert_eq!(collection.tool_events.len(), 1);
+        assert_eq!(collection.tool_events[0].tool_name, "web_fetch");
+    }
+
+    /// A resumed session appends a SECOND shutdown whose totals are
+    /// cumulative — per (session, model) the larger (later) totals win and
+    /// nothing is summed twice.
+    #[test]
+    fn resumed_session_cumulative_shutdowns_count_once() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.start","timestamp":"2026-07-27T12:40:52.292Z","data":{"sessionId":"s1","context":{"cwd":"/Users/me/code/app"}}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:41:08.275Z","data":{"shutdownType":"routine","modelMetrics":{"gpt-5-mini":{"requests":{"count":1,"cost":0},"usage":{"inputTokens":14166,"outputTokens":150,"cacheReadTokens":1536,"cacheWriteTokens":0,"reasoningTokens":128}}}}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:42:15.207Z","data":{"shutdownType":"routine","modelMetrics":{"gpt-5-mini":{"requests":{"count":2,"cost":0},"usage":{"inputTokens":28406,"outputTokens":286,"cacheReadTokens":10240,"cacheWriteTokens":0,"reasoningTokens":256}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 1);
+        let event = &collection.usage_events[0];
+        // The cumulative (larger) totals win; summing both would report
+        // 42,572 input instead of the session's true 28,406.
+        assert_eq!(event.usage.token_volume(), 28_406 + 286);
+        // Earliest timestamp is retained for attribution.
+        let first = OffsetDateTime::parse("2026-07-27T12:41:08.275Z", &Rfc3339)
+            .expect("test timestamp should parse");
+        assert_eq!(event.timestamp, Some(first));
+    }
+
+    /// A session that never exited cleanly has no shutdown — and no token
+    /// data. It must contribute activity only, not usage.
+    #[test]
+    fn session_without_shutdown_has_no_usage() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.start","timestamp":"2026-07-23T14:58:00.000Z","data":{"sessionId":"s1","context":{"cwd":"/Users/me/code/app"}}}"#,
+                "\n",
+                r#"{"type":"session.usage_checkpoint","timestamp":"2026-07-23T14:59:54.634Z","data":{"totalNanoAiu":1958555000,"totalPremiumRequests":0}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 0);
+        assert!(!collection.session_touches.is_empty());
+    }
+
+    /// Multi-model sessions split per model under one session key space.
+    #[test]
+    fn multi_model_shutdown_splits_per_model() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:41:08.275Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}},"claude-sonnet-4.6":{"usage":{"inputTokens":200,"outputTokens":20,"cacheReadTokens":50,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 2);
+        let total: u64 = collection
+            .usage_events
+            .iter()
+            .map(|event| event.usage.token_volume())
+            .sum();
+        assert_eq!(total, 110 + 220);
+    }
+}

--- a/src/collector/copilot.rs
+++ b/src/collector/copilot.rs
@@ -9,10 +9,12 @@ use time::format_description::well_known::Rfc3339;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedToolEvent, KeyedUsageEvent, merge_into, parse_files_cached, project_from_cwd,
+    FileEvents, KeyedCreditSample, KeyedToolEvent, KeyedUsageEvent, merge_into, parse_files_cached,
+    project_from_cwd,
 };
 use crate::model::{
-    Collection, Provider, SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
+    Collection, CreditSample, DurationEvent, Provider, SessionTouch, SourceKind, TokenUsage,
+    ToolEvent, UsageEvent,
 };
 
 /// GitHub Copilot CLI (`@github/copilot`, the agentic CLI — not the retired
@@ -99,6 +101,9 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
     let mut project: Option<String> = None;
     let mut cumulative: HashMap<String, RawCounters> = HashMap::new();
     let mut shutdown_index = 0usize;
+    let mut last_nano_aiu = 0u64;
+    let mut credit_index = 0usize;
+    let mut turn_starts: HashMap<String, OffsetDateTime> = HashMap::new();
     let reader = BufReader::new(file);
 
     for line in reader.lines() {
@@ -140,7 +145,46 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
             Some("tool.execution_start") => {
                 collect_tool_event(&value, timestamp, session_id.as_ref(), &mut events);
             }
+            // Explicit turn boundaries (unlike Claude, whose turn durations
+            // are inferred from prompt-to-activity gaps) — pair start/end by
+            // turnId for the COMPLETION panel.
+            Some("assistant.turn_start") => {
+                if let (Some(turn_id), Some(timestamp)) = (turn_id(&value), timestamp) {
+                    turn_starts.insert(turn_id, timestamp);
+                }
+            }
+            Some("assistant.turn_end") => {
+                collect_turn_duration(
+                    &value,
+                    timestamp,
+                    session_id.as_ref(),
+                    &mut turn_starts,
+                    &mut events,
+                );
+            }
+            // `totalNanoAiu` is a cumulative AI-credit ledger carried on both
+            // periodic checkpoints and shutdowns — unlike tokens it exists
+            // even for sessions that never exit cleanly. Deltas feed the
+            // CREDITS history.
+            Some("session.usage_checkpoint") => {
+                collect_credit_delta(
+                    &value,
+                    timestamp,
+                    session_id.as_ref(),
+                    &mut last_nano_aiu,
+                    &mut credit_index,
+                    &mut events,
+                );
+            }
             Some("session.shutdown") => {
+                collect_credit_delta(
+                    &value,
+                    timestamp,
+                    session_id.as_ref(),
+                    &mut last_nano_aiu,
+                    &mut credit_index,
+                    &mut events,
+                );
                 collect_shutdown_usage(
                     &value,
                     timestamp,
@@ -270,6 +314,81 @@ fn collect_shutdown_usage(
             },
         });
     }
+}
+
+/// Close a turn: pair the `turn_end` with its recorded `turn_start` by
+/// turnId and emit the explicit duration.
+fn collect_turn_duration(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    turn_starts: &mut HashMap<String, OffsetDateTime>,
+    events: &mut FileEvents,
+) {
+    if let (Some(turn_id), Some(end)) = (turn_id(value), timestamp)
+        // Validate before consuming: a clock-skewed (end < start) record must
+        // not eat the start entry, or a later valid end could never pair.
+        && turn_starts.get(&turn_id).is_some_and(|start| end >= *start)
+        && let Some(start) = turn_starts.remove(&turn_id)
+    {
+        events.duration_events.push(DurationEvent {
+            timestamp: Some(end),
+            session_id: session_id.cloned(),
+            duration_ms: u64::try_from((end - start).whole_milliseconds()).unwrap_or(0),
+            status: Some("turn".to_owned()),
+        });
+    }
+}
+
+fn turn_id(value: &Value) -> Option<String> {
+    value
+        .get("data")
+        .and_then(|data| data.get("turnId"))
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+/// AI-credit spend since the previous checkpoint of this session, from the
+/// cumulative `totalNanoAiu`. A value going backwards (CLI update / epoch
+/// reset) counts the fresh cumulative in full, mirroring the token rule.
+fn collect_credit_delta(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    last_nano_aiu: &mut u64,
+    credit_index: &mut usize,
+    events: &mut FileEvents,
+) {
+    let Some(timestamp) = timestamp else {
+        return;
+    };
+    // Untrusted log data: clamp like token counts so downstream daily sums
+    // can never overflow (1<<50 nano-AIU ≈ a million credits).
+    let Some(current) = value
+        .get("data")
+        .and_then(|data| data.get("totalNanoAiu"))
+        .and_then(Value::as_u64)
+        .map(|nano| nano.min(1 << 50))
+    else {
+        return;
+    };
+    let delta = if current < *last_nano_aiu {
+        current
+    } else {
+        current - *last_nano_aiu
+    };
+    *last_nano_aiu = current;
+    if delta == 0 {
+        return;
+    }
+    events.credit_samples.push(KeyedCreditSample {
+        key: session_id.map(|sid| format!("copilot-credit:{sid}:{index}", index = *credit_index)),
+        event: CreditSample {
+            timestamp,
+            nano_aiu: delta,
+        },
+    });
+    *credit_index += 1;
 }
 
 fn collect_tool_event(
@@ -521,6 +640,123 @@ mod tests {
 
         assert_eq!(collection.usage_events.len(), 0);
         assert!(!collection.session_touches.is_empty());
+        // Credits exist even without a clean exit — the checkpoint ledger.
+        assert_eq!(collection.credit_samples.len(), 1);
+        assert_eq!(collection.credit_samples[0].nano_aiu, 1_958_555_000);
+    }
+
+    /// Credits accrue as deltas of the cumulative nano-AIU ledger across
+    /// checkpoints and shutdown, attributed to each record's own time.
+    #[test]
+    fn credit_deltas_accrue_across_checkpoints_and_shutdown() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.usage_checkpoint","timestamp":"2026-07-27T10:00:00.000Z","data":{"totalNanoAiu":1000000000,"totalPremiumRequests":0}}"#,
+                "\n",
+                r#"{"type":"session.usage_checkpoint","timestamp":"2026-07-27T11:00:00.000Z","data":{"totalNanoAiu":3500000000,"totalPremiumRequests":0}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:00:00.000Z","data":{"totalNanoAiu":4000000000,"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":100,"outputTokens":10,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        let deltas: Vec<u64> = collection
+            .credit_samples
+            .iter()
+            .map(|sample| sample.nano_aiu)
+            .collect();
+        assert_eq!(deltas, vec![1_000_000_000, 2_500_000_000, 500_000_000]);
+    }
+
+    /// The nano-AIU ledger resetting (decrease) starts a new epoch counted
+    /// in full: 100→40→70 counts 100+40+30, and a reset through zero
+    /// (100→0→30) counts 100+30. A shutdown carrying the same cumulative as
+    /// the last checkpoint deltas to zero and adds nothing.
+    #[test]
+    fn credit_resets_and_equal_snapshots() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.usage_checkpoint","timestamp":"2026-07-27T10:00:00.000Z","data":{"totalNanoAiu":100}}"#,
+                "\n",
+                r#"{"type":"session.usage_checkpoint","timestamp":"2026-07-27T10:10:00.000Z","data":{"totalNanoAiu":40}}"#,
+                "\n",
+                r#"{"type":"session.usage_checkpoint","timestamp":"2026-07-27T10:20:00.000Z","data":{"totalNanoAiu":70}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T10:30:00.000Z","data":{"totalNanoAiu":70,"modelMetrics":{}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        let total: u64 = collection
+            .credit_samples
+            .iter()
+            .map(|sample| sample.nano_aiu)
+            .sum();
+        // 100 (first) + 40 (reset epoch) + 30 (delta) + 0 (equal shutdown).
+        assert_eq!(total, 170);
+        assert_eq!(collection.credit_samples.len(), 3);
+    }
+
+    /// A clock-skewed `turn_end` (before its start) must not consume the
+    /// start entry — the later valid end still pairs.
+    #[test]
+    fn skewed_turn_end_does_not_eat_the_start() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"assistant.turn_start","timestamp":"2026-07-27T12:00:10.000Z","data":{"turnId":"0"}}"#,
+                "\n",
+                r#"{"type":"assistant.turn_end","timestamp":"2026-07-27T12:00:05.000Z","data":{"turnId":"0"}}"#,
+                "\n",
+                r#"{"type":"assistant.turn_end","timestamp":"2026-07-27T12:00:20.000Z","data":{"turnId":"0"}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.duration_events.len(), 1);
+        assert_eq!(collection.duration_events[0].duration_ms, 10_000);
+    }
+
+    /// Turn durations pair `assistant.turn_start` / `turn_end` by turnId —
+    /// explicit boundaries, no heuristics.
+    #[test]
+    fn turn_durations_pair_start_and_end_by_turn_id() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"assistant.turn_start","timestamp":"2026-07-27T12:00:00.000Z","data":{"turnId":"0"}}"#,
+                "\n",
+                r#"{"type":"assistant.turn_end","timestamp":"2026-07-27T12:00:08.000Z","data":{"turnId":"0"}}"#,
+                "\n",
+                r#"{"type":"assistant.turn_end","timestamp":"2026-07-27T12:00:09.000Z","data":{"turnId":"unmatched"}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.duration_events.len(), 1);
+        assert_eq!(collection.duration_events[0].duration_ms, 8_000);
+        assert_eq!(
+            collection.duration_events[0].status.as_deref(),
+            Some("turn")
+        );
     }
 
     /// Multi-model sessions split per model under one session key space.

--- a/src/collector/copilot.rs
+++ b/src/collector/copilot.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
@@ -25,9 +26,14 @@ use crate::model::{
 ///   and therefore no token data — a documented gap, recovered when the
 ///   session eventually exits (the cumulative shutdown covers its lifetime).
 /// - Resuming appends to the SAME session file and a later clean exit appends
-///   ANOTHER shutdown whose totals are cumulative, so per (session, model)
-///   only the last shutdown may count. `merge_into`'s larger-volume-wins rule
-///   on the `copilot:{session}:{model}` key does exactly that.
+///   ANOTHER shutdown whose totals are cumulative. Each shutdown therefore
+///   emits the component-wise DELTA since the previous snapshot, dated at its
+///   own exit time — never the raw cumulative. Keeping one cumulative event
+///   instead would mis-window resumed sessions: the merged event would carry
+///   the latest totals at the EARLIEST exit's date, so a session first closed
+///   before the analysis window and resumed today would drop today's usage
+///   entirely. A counter going backwards (CLI update / metric reset) starts a
+///   new epoch and the snapshot counts in full.
 pub fn collect(
     root: &Path,
     mtime_floor: Option<SystemTime>,
@@ -47,8 +53,16 @@ pub fn collect(
     if let Ok(entries) = std::fs::read_dir(&sessions) {
         for entry in entries.flatten() {
             let path = entry.path().join("events.jsonl");
-            let Ok(meta) = std::fs::metadata(&path) else {
-                continue;
+            let meta = match std::fs::metadata(&path) {
+                Ok(meta) => meta,
+                // Absent is the normal case (not every session dir has an
+                // event stream); anything else is a real read failure worth
+                // surfacing in the stats line.
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(_) => {
+                    collection.stats.unreadable_files += 1;
+                    continue;
+                }
             };
             if let (Some(floor), Ok(mtime)) = (mtime_floor, meta.modified())
                 && mtime < floor
@@ -83,6 +97,8 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
         .map(ToOwned::to_owned);
     let mut events = FileEvents::default();
     let mut project: Option<String> = None;
+    let mut cumulative: HashMap<String, RawCounters> = HashMap::new();
+    let mut shutdown_index = 0usize;
     let reader = BufReader::new(file);
 
     for line in reader.lines() {
@@ -130,8 +146,11 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
                     timestamp,
                     session_id.as_ref(),
                     project.as_deref(),
+                    &mut cumulative,
+                    shutdown_index,
                     &mut events,
                 );
+                shutdown_index += 1;
             }
             _ => {}
         }
@@ -141,17 +160,56 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
     Some(events)
 }
 
-/// Per-model cumulative usage from a `session.shutdown`. Field semantics
-/// verified against the CLI's own on-screen totals: `inputTokens` INCLUDES
-/// `cacheReadTokens` (14,166 = 12,630 fresh + 1,536 cached in the probe
-/// session), so fresh input is the difference — the same convention as
-/// Codex. `reasoningTokens` is a subset of `outputTokens` and is tracked
-/// without being added to the volume.
+/// Raw cumulative counters from one `modelMetrics` entry, as logged:
+/// `input` includes `cache_read`, `output` includes `reasoning`.
+#[derive(Clone, Copy, Default)]
+struct RawCounters {
+    input: u64,
+    output: u64,
+    cache_read: u64,
+    cache_write: u64,
+    reasoning: u64,
+}
+
+impl RawCounters {
+    fn any_less_than(self, other: Self) -> bool {
+        self.input < other.input
+            || self.output < other.output
+            || self.cache_read < other.cache_read
+            || self.cache_write < other.cache_write
+            || self.reasoning < other.reasoning
+    }
+
+    fn minus(self, other: Self) -> Self {
+        Self {
+            input: self.input.saturating_sub(other.input),
+            output: self.output.saturating_sub(other.output),
+            cache_read: self.cache_read.saturating_sub(other.cache_read),
+            cache_write: self.cache_write.saturating_sub(other.cache_write),
+            reasoning: self.reasoning.saturating_sub(other.reasoning),
+        }
+    }
+}
+
+/// Per-model usage from a `session.shutdown`: the component-wise delta since
+/// the previous shutdown snapshot of the same model, so every clean exit is
+/// counted once at its own time (see the module doc for why the cumulative
+/// must not be kept whole). Field semantics verified against the CLI's own
+/// on-screen totals: `inputTokens` INCLUDES `cacheReadTokens` (14,166 =
+/// 12,630 fresh + 1,536 cached in the probe session), so fresh input is the
+/// difference — the same convention as Codex. `reasoningTokens` is a subset
+/// of `outputTokens` and is tracked without being added to the volume.
+#[allow(
+    clippy::too_many_arguments,
+    reason = "Per-line parse context; bundling into a struct adds noise for one caller."
+)]
 fn collect_shutdown_usage(
     value: &Value,
     timestamp: Option<OffsetDateTime>,
     session_id: Option<&String>,
     project: Option<&str>,
+    cumulative: &mut HashMap<String, RawCounters>,
+    shutdown_index: usize,
     events: &mut FileEvents,
 ) {
     let Some(metrics) = value
@@ -165,14 +223,40 @@ fn collect_shutdown_usage(
         let Some(usage) = entry.get("usage") else {
             continue;
         };
-        let input_tokens = u64_field(usage, "inputTokens");
-        let output_tokens = u64_field(usage, "outputTokens");
-        let cache_read = u64_field(usage, "cacheReadTokens");
-        if input_tokens == 0 && output_tokens == 0 {
+        let current = RawCounters {
+            input: u64_field(usage, "inputTokens"),
+            output: u64_field(usage, "outputTokens"),
+            cache_read: u64_field(usage, "cacheReadTokens"),
+            cache_write: u64_field(usage, "cacheWriteTokens"),
+            reasoning: u64_field(usage, "reasoningTokens"),
+        };
+        let previous = cumulative.get(model).copied().unwrap_or_default();
+        // A counter going backwards means the CLI restarted its accounting
+        // (update, epoch change): the snapshot is a fresh cumulative, not a
+        // continuation, so it counts in full.
+        let base = if current.any_less_than(previous) {
+            RawCounters::default()
+        } else {
+            previous
+        };
+        let delta = current.minus(base);
+        cumulative.insert(model.clone(), current);
+
+        let usage = TokenUsage {
+            input_tokens: delta.input.saturating_sub(delta.cache_read),
+            output_tokens: delta.output,
+            reasoning_output_tokens: delta.reasoning,
+            cache_read_input_tokens: delta.cache_read,
+            cache_creation_input_tokens: delta.cache_write,
+            ..TokenUsage::default()
+        };
+        // A re-emitted identical snapshot (an exit with no new activity)
+        // deltas to zero and adds nothing.
+        if usage.token_volume() == 0 {
             continue;
         }
         events.usage_events.push(KeyedUsageEvent {
-            key: session_id.map(|sid| format!("copilot:{sid}:{model}")),
+            key: session_id.map(|sid| format!("copilot:{sid}:{model}:{shutdown_index}")),
             event: UsageEvent {
                 timestamp,
                 session_id: session_id.cloned(),
@@ -181,14 +265,7 @@ fn collect_shutdown_usage(
                 attribution_agent: None,
                 attribution_skill: None,
                 project: project.map(ToOwned::to_owned),
-                usage: TokenUsage {
-                    input_tokens: input_tokens.saturating_sub(cache_read),
-                    output_tokens,
-                    reasoning_output_tokens: u64_field(usage, "reasoningTokens"),
-                    cache_read_input_tokens: cache_read,
-                    cache_creation_input_tokens: u64_field(usage, "cacheWriteTokens"),
-                    ..TokenUsage::default()
-                },
+                usage,
                 reported_cost_usd: None,
             },
         });
@@ -207,10 +284,13 @@ fn collect_tool_event(
     let Some(tool_name) = data.get("toolName").and_then(Value::as_str) else {
         return;
     };
-    let key = data
-        .get("toolCallId")
-        .and_then(Value::as_str)
-        .map(|id| format!("copilot-tool:{id}"));
+    // Scoped per session: toolCallId uniqueness across sessions is not
+    // guaranteed by anything we verified, and the seen-set in merge_into is
+    // global.
+    let key = match (session_id, data.get("toolCallId").and_then(Value::as_str)) {
+        (Some(sid), Some(id)) => Some(format!("copilot-tool:{sid}:{id}")),
+        _ => None,
+    };
     events.tool_events.push(KeyedToolEvent {
         key,
         event: ToolEvent {
@@ -281,11 +361,12 @@ mod tests {
         assert_eq!(collection.tool_events[0].tool_name, "web_fetch");
     }
 
-    /// A resumed session appends a SECOND shutdown whose totals are
-    /// cumulative — per (session, model) the larger (later) totals win and
-    /// nothing is summed twice.
+    /// A resumed session appends a SECOND shutdown with cumulative totals:
+    /// each shutdown must emit only its delta, dated at its own exit — so a
+    /// segment inside the analysis window survives even when an earlier exit
+    /// falls outside it.
     #[test]
-    fn resumed_session_cumulative_shutdowns_count_once() {
+    fn resumed_session_counts_each_segment_at_its_own_exit() {
         let temp = TempDir::new().expect("test tempdir should be created");
         write_session(
             temp.path(),
@@ -302,15 +383,122 @@ mod tests {
 
         let collection = collect(temp.path(), None, false, UtcOffset::UTC);
 
-        assert_eq!(collection.usage_events.len(), 1);
-        let event = &collection.usage_events[0];
-        // The cumulative (larger) totals win; summing both would report
-        // 42,572 input instead of the session's true 28,406.
-        assert_eq!(event.usage.token_volume(), 28_406 + 286);
-        // Earliest timestamp is retained for attribution.
-        let first = OffsetDateTime::parse("2026-07-27T12:41:08.275Z", &Rfc3339)
+        assert_eq!(collection.usage_events.len(), 2);
+        let first = &collection.usage_events[0];
+        let second = &collection.usage_events[1];
+        assert_eq!(first.usage.token_volume(), 14_166 + 150);
+        // Second segment: 28,406 − 14,166 input and 286 − 150 output.
+        assert_eq!(second.usage.token_volume(), 14_240 + 136);
+        // Summing raw cumulatives would have reported 42,572 input.
+        let total: u64 = collection
+            .usage_events
+            .iter()
+            .map(|event| event.usage.token_volume())
+            .sum();
+        assert_eq!(total, 28_406 + 286);
+        // Each segment keeps its own exit timestamp.
+        let t1 = OffsetDateTime::parse("2026-07-27T12:41:08.275Z", &Rfc3339)
             .expect("test timestamp should parse");
-        assert_eq!(event.timestamp, Some(first));
+        let t2 = OffsetDateTime::parse("2026-07-27T12:42:15.207Z", &Rfc3339)
+            .expect("test timestamp should parse");
+        assert_eq!(first.timestamp, Some(t1));
+        assert_eq!(second.timestamp, Some(t2));
+    }
+
+    /// A cumulative counter going backwards (CLI update / metric reset)
+    /// starts a new epoch: the snapshot counts in full, never a negative or
+    /// zero delta.
+    #[test]
+    fn cumulative_reset_counts_new_epoch_in_full() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T13:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":400,"outputTokens":40,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 2);
+        let total: u64 = collection
+            .usage_events
+            .iter()
+            .map(|event| event.usage.token_volume())
+            .sum();
+        assert_eq!(total, 1_100 + 440);
+    }
+
+    /// An exit with no new activity re-emits the identical snapshot — the
+    /// delta is zero and nothing is added.
+    #[test]
+    fn identical_snapshot_reemission_adds_nothing() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        let shutdown = r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#;
+        write_session(temp.path(), "s1", &format!("{shutdown}\n{shutdown}\n"));
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.usage_events[0].usage.token_volume(), 1_100);
+    }
+
+    /// Cache writes are billed volume even when input/output stay zero.
+    #[test]
+    fn cache_write_only_snapshot_is_counted() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":0,"outputTokens":0,"cacheReadTokens":0,"cacheWriteTokens":500,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.usage_events.len(), 1);
+        assert_eq!(collection.usage_events[0].usage.token_volume(), 500);
+    }
+
+    /// toolCallId uniqueness across sessions is unverified — the dedup key is
+    /// scoped per session so two sessions reusing an id both count.
+    #[test]
+    fn tool_call_ids_are_scoped_per_session() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        let line = r#"{"type":"tool.execution_start","timestamp":"2026-07-27T12:00:00.000Z","data":{"toolCallId":"call_1","toolName":"web_fetch"}}"#;
+        write_session(temp.path(), "s1", &format!("{line}\n"));
+        write_session(temp.path(), "s2", &format!("{line}\n"));
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.tool_events.len(), 2);
+    }
+
+    /// A malformed line is skipped without aborting the file — the shutdown
+    /// after it still counts.
+    #[test]
+    fn malformed_line_does_not_abort_the_file() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        write_session(
+            temp.path(),
+            "s1",
+            concat!(
+                "not json at all\n",
+                r#"{"type":"session.shutdown","timestamp":"2026-07-27T12:00:00.000Z","data":{"modelMetrics":{"gpt-5-mini":{"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":0,"cacheWriteTokens":0,"reasoningTokens":0}}}}}"#,
+                "\n"
+            ),
+        );
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.stats.parse_errors, 1);
+        assert_eq!(collection.usage_events.len(), 1);
     }
 
     /// A session that never exited cleanly has no shutdown — and no token

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -2,6 +2,7 @@ pub mod agy;
 mod agy_conv;
 pub mod claude;
 pub mod codex;
+pub mod copilot;
 pub mod cursor;
 pub mod opencode;
 

--- a/src/collector/mod.rs
+++ b/src/collector/mod.rs
@@ -17,8 +17,8 @@ use time::{Date, OffsetDateTime, UtcOffset};
 use tracing::debug;
 
 use crate::model::{
-    Collection, DurationEvent, EffortEvent, ModeEvent, RateLimitSample, ScanStats, SessionTouch,
-    ToolEvent, UsageEvent,
+    Collection, CreditSample, DurationEvent, EffortEvent, ModeEvent, RateLimitSample, ScanStats,
+    SessionTouch, ToolEvent, UsageEvent,
 };
 
 /// Bump whenever the serialized layout OR the parsing semantics (event
@@ -36,9 +36,11 @@ use crate::model::{
 ///   same layout, but cached events carry the old positional keys.
 /// - 11: Claude `usage.iterations` parsing (fallback/advisor calls) — cached
 ///   `FileEvents` lack the iteration events.
+/// - 12: `FileEvents` gained `credit_samples` (Copilot CREDITS), changing its
+///   bincode layout.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
-const CACHE_VERSION: u32 = 11;
+const CACHE_VERSION: u32 = 12;
 
 /// Normalize a working-directory path into a project label: strip the home
 /// prefix and (on Windows) normalize separators to `/` so the same repo
@@ -126,6 +128,7 @@ pub struct FileEvents {
     pub session_touches: Vec<SessionTouch>,
     pub duration_events: Vec<DurationEvent>,
     pub rate_limit_samples: Vec<KeyedRateLimitSample>,
+    pub credit_samples: Vec<KeyedCreditSample>,
     pub effort_events: Vec<KeyedEffortEvent>,
     pub mode_events: Vec<KeyedModeEvent>,
     pub lines_seen: usize,
@@ -150,6 +153,12 @@ pub struct KeyedToolEvent {
 pub struct KeyedRateLimitSample {
     pub key: Option<String>,
     pub event: RateLimitSample,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedCreditSample {
+    pub key: Option<String>,
+    pub event: CreditSample,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -507,6 +516,7 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
     let mut seen_usage: HashMap<String, usize> = HashMap::new();
     let mut seen_tools: HashMap<String, usize> = HashMap::new();
     let mut seen_limits: HashMap<String, usize> = HashMap::new();
+    let mut seen_credits: HashMap<String, usize> = HashMap::new();
     let mut seen_efforts: HashMap<String, usize> = HashMap::new();
     let mut seen_modes: HashMap<String, usize> = HashMap::new();
 
@@ -558,6 +568,18 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
             dedupe_into(
                 &mut collection.rate_limit_samples,
                 &mut seen_limits,
+                keyed.key,
+                keyed.event,
+                |existing, incoming| {
+                    existing.timestamp = existing.timestamp.min(incoming.timestamp);
+                },
+            );
+        }
+
+        for keyed in events.credit_samples {
+            dedupe_into(
+                &mut collection.credit_samples,
+                &mut seen_credits,
                 keyed.key,
                 keyed.event,
                 |existing, incoming| {

--- a/src/cost.rs
+++ b/src/cost.rs
@@ -186,7 +186,10 @@ fn normalize(model_name: &str) -> String {
 /// `claude-sonnet-4-5`) or the `-latest` alias (`claude-sonnet-4-5-latest`). A
 /// plain word suffix (`gemini-pro-default`) must not collide with a shorter base
 /// key — without that guard, dropping the provider allowlist would let unrelated
-/// ids misprice.
+/// ids misprice. When the literal name misses entirely, dotted version
+/// segments are retried dashed (`claude-sonnet-4.6` -> `claude-sonnet-4-6`,
+/// the Copilot CLI's spelling) — only as a fallback, so ids whose pricing
+/// keys genuinely contain dots (`gpt-3.5-turbo`) resolve exactly first.
 pub fn pricing_for(model_name: &str) -> Option<Pricing> {
     let mut name = normalize(model_name);
     if name == "codex" || name == "openai" || name == "codex-auto-review" {
@@ -198,10 +201,21 @@ pub fn pricing_for(model_name: &str) -> Option<Pricing> {
 
     let loaded = loaded().read().ok()?;
     let snapshot = loaded.as_ref()?;
-    if let Some(pricing) = snapshot.models.get(&name) {
+    if let Some(pricing) = lookup(snapshot, &name) {
+        return Some(pricing);
+    }
+    let dashed = name.replace('.', "-");
+    if dashed != name {
+        return lookup(snapshot, &dashed);
+    }
+    None
+}
+
+fn lookup(snapshot: &Snapshot, name: &str) -> Option<Pricing> {
+    if let Some(pricing) = snapshot.models.get(name) {
         return Some(*pricing);
     }
-    if let Some(pricing) = snapshot
+    snapshot
         .models
         .iter()
         .filter(|(key, _)| {
@@ -215,10 +229,6 @@ pub fn pricing_for(model_name: &str) -> Option<Pricing> {
         })
         .max_by_key(|(key, _)| key.len())
         .map(|(_, pricing)| *pricing)
-    {
-        return Some(pricing);
-    }
-    None
 }
 
 /// API-equivalent USD cost of an aggregated usage block for a model.
@@ -260,6 +270,21 @@ mod tests {
 
     use super::*;
 
+    /// Copilot logs Claude models with dotted version segments; the dashed
+    /// retry resolves them, while ids whose pricing keys genuinely contain
+    /// dots keep matching exactly first.
+    #[test]
+    fn dotted_model_names_resolve_to_dashed_pricing_keys() {
+        install_test_pricing();
+        let dotted = pricing_for("claude-sonnet-4.5").expect("dotted name should resolve");
+        let dashed = pricing_for("claude-sonnet-4-5").expect("dashed name should resolve");
+        assert!((dotted.input - dashed.input).abs() < f64::EPSILON);
+        // A pricing key that itself contains a dot resolves exactly, before
+        // any dash rewriting.
+        let real_dot = pricing_for("gpt-3.5-turbo").expect("dotted key should resolve");
+        assert!((real_dot.input - 0.5 / 1e6).abs() < f64::EPSILON);
+    }
+
     fn install_test_pricing() {
         let per_mtok =
             |input: f64, output: f64, cache_write_5m: f64, cache_write_1h: f64| Pricing {
@@ -281,6 +306,7 @@ mod tests {
                     "claude-sonnet-4-5".to_owned(),
                     per_mtok(3.0, 15.0, 3.75, 6.0),
                 ),
+                ("gpt-3.5-turbo".to_owned(), per_mtok(0.5, 1.5, 0.0, 0.0)),
                 (
                     "gpt-5.5".to_owned(),
                     Pricing {

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -11,8 +11,8 @@ use time::{Duration, OffsetDateTime, Time, Weekday};
 use crate::analyzer::summarize;
 use crate::app::Config;
 use crate::model::{
-    AppSummary, Collection, DurationEvent, EffortEvent, ModeEvent, Provider, RateLimitSample,
-    SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
+    AppSummary, Collection, CreditSample, DurationEvent, EffortEvent, ModeEvent, Provider,
+    RateLimitSample, SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
 };
 
 struct Rng(u64);
@@ -391,6 +391,87 @@ fn codex_collection(now: OffsetDateTime, days: u16, rng: &mut Rng) -> Collection
     collection
 }
 
+/// Copilot demo: session-exit token deltas plus the AI-credit ledger the
+/// CREDITS panel renders. Kept lighter than Claude/Codex — a secondary agent
+/// in the demo persona.
+#[allow(
+    clippy::cast_precision_loss,
+    reason = "Day indices are tiny; precision is irrelevant for fake data."
+)]
+fn copilot_collection(now: OffsetDateTime, days: u16, rng: &mut Rng) -> Collection {
+    let mut collection = Collection::new(Provider::Copilot, PathBuf::from("demo data"));
+    let total_days = i64::from(days.max(1));
+
+    for day_index in 0..total_days {
+        let date = (now - Duration::days(total_days - 1 - day_index)).date();
+        let progress = day_index as f64 / total_days as f64;
+        let volume = daily_volume(rng, progress, date.weekday()) / 12;
+        if volume == 0 || rng.chance(45) {
+            continue;
+        }
+
+        let session_id = format!("demo-copilot-{day_index}");
+        let hour = pick_hour(rng);
+        let time = Time::from_hms(hour, u8::try_from(rng.range(0, 60)).unwrap_or(0), 0)
+            .unwrap_or(Time::MIDNIGHT);
+        let timestamp = date.with_time(time).assume_offset(now.offset());
+
+        collection.usage_events.push(UsageEvent {
+            timestamp: Some(timestamp),
+            session_id: Some(session_id.clone()),
+            model: Some(
+                if rng.chance(60) {
+                    "gpt-5-mini"
+                } else {
+                    "claude-sonnet-4.6"
+                }
+                .to_owned(),
+            ),
+            source_kind: SourceKind::Main,
+            attribution_agent: None,
+            attribution_skill: None,
+            project: Some(pick_project(rng)),
+            usage: usage_block(rng, volume),
+            reported_cost_usd: None,
+        });
+        // Daily AI-credit spend in nano-AIU; a mid-period spike gives the
+        // CREDITS chart a visible peak.
+        let credits = if day_index == total_days * 2 / 3 {
+            rng.range(4_000, 6_000)
+        } else {
+            rng.range(50, 1_500)
+        };
+        collection.credit_samples.push(CreditSample {
+            timestamp,
+            nano_aiu: credits * 1_000_000,
+        });
+        collection.session_touches.push(SessionTouch {
+            timestamp,
+            session_id: session_id.clone(),
+        });
+        collection.session_touches.push(SessionTouch {
+            timestamp: timestamp
+                + Duration::minutes(i64::try_from(rng.range(10, 60)).unwrap_or(20)),
+            session_id: session_id.clone(),
+        });
+        let turns = rng.range(1, 3);
+        for _ in 0..turns {
+            collection.duration_events.push(DurationEvent {
+                timestamp: Some(timestamp),
+                session_id: Some(session_id.clone()),
+                duration_ms: turn_duration_ms(rng),
+                status: Some("turn".to_owned()),
+            });
+        }
+    }
+
+    collection.stats.files_seen = 18;
+    collection.stats.lines_seen = 4_112;
+    collection.stats.usage_events = collection.usage_events.len();
+    collection.stats.duration_events = collection.duration_events.len();
+    collection
+}
+
 /// Build a complete synthetic report through the real analyzer, so the demo
 /// exercises exactly the rendering paths real data does.
 pub fn demo_report(config: &Config) -> AppSummary {
@@ -400,6 +481,7 @@ pub fn demo_report(config: &Config) -> AppSummary {
     let collections = vec![
         claude_collection(now, config.days, &mut rng),
         codex_collection(now, config.days, &mut rng),
+        copilot_collection(now, config.days, &mut rng),
         Collection::new(Provider::Agy, PathBuf::from("demo data")),
     ];
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -11,6 +11,7 @@ pub enum Provider {
     Codex,
     Agy,
     OpenCode,
+    Copilot,
     Cursor,
 }
 
@@ -22,6 +23,7 @@ impl Provider {
             Self::Codex => "Codex",
             Self::Agy => "Agy",
             Self::OpenCode => "OpenCode",
+            Self::Copilot => "Copilot",
             Self::Cursor => "Cursor",
         }
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -142,6 +142,15 @@ pub struct RateLimitSample {
     pub used_percent: f64,
 }
 
+/// One interval's AI-credit spend: the delta of Copilot's cumulative
+/// `totalNanoAiu` between consecutive usage checkpoints / shutdowns.
+/// 1 credit = 1e9 nano-AIU.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreditSample {
+    pub timestamp: OffsetDateTime,
+    pub nano_aiu: u64,
+}
+
 /// One Codex turn's reasoning-effort setting (`turn_context.payload.effort`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EffortEvent {
@@ -193,6 +202,7 @@ pub struct Collection {
     pub session_touches: Vec<SessionTouch>,
     pub duration_events: Vec<DurationEvent>,
     pub rate_limit_samples: Vec<RateLimitSample>,
+    pub credit_samples: Vec<CreditSample>,
     pub effort_events: Vec<EffortEvent>,
     pub mode_events: Vec<ModeEvent>,
     pub stats: ScanStats,
@@ -208,6 +218,7 @@ impl Collection {
             session_touches: Vec::new(),
             duration_events: Vec::new(),
             rate_limit_samples: Vec::new(),
+            credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             stats: ScanStats::default(),
@@ -232,6 +243,9 @@ impl Collection {
             combined
                 .rate_limit_samples
                 .extend(collection.rate_limit_samples.iter().cloned());
+            combined
+                .credit_samples
+                .extend(collection.credit_samples.iter().cloned());
             combined
                 .effort_events
                 .extend(collection.effort_events.iter().cloned());
@@ -318,6 +332,16 @@ pub enum LimitDay {
 #[derive(Debug, Clone)]
 pub struct LimitsHistory {
     pub days: Vec<(Date, LimitDay)>,
+    pub peak: Option<(Date, f64)>,
+}
+
+/// Daily AI-credit spend over the fixed 30-day window (Copilot). Historical
+/// by design — spend that already happened, not a remaining-quota meter.
+#[derive(Debug, Clone)]
+pub struct CreditsHistory {
+    /// One entry per window day; 0.0 = no recorded spend.
+    pub days: Vec<(Date, f64)>,
+    pub total: f64,
     pub peak: Option<(Date, f64)>,
 }
 
@@ -420,6 +444,7 @@ pub struct Summary {
     /// all-time cut would silently under-count.
     pub skills: Vec<SkillStat>,
     pub limits: Option<LimitsHistory>,
+    pub credits: Option<CreditsHistory>,
     pub modes: ModesSummary,
     pub tools: Vec<ToolStat>,
     pub projects: Vec<ProjectStat>,

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -66,6 +66,15 @@ pub fn agy_home() -> Result<PathBuf> {
     Ok(home_dir()?.join(".gemini").join("antigravity-cli"))
 }
 
+/// Root directory GitHub Copilot CLI writes. `COPILOT_HOME` overrides it;
+/// the default is `~/.copilot`, with session logs under
+/// `<root>/session-state/<uuid>/events.jsonl`.
+pub fn copilot_home() -> Result<PathBuf> {
+    resolve_root(std::env::var_os("COPILOT_HOME"), || {
+        Ok(home_dir()?.join(".copilot"))
+    })
+}
+
 /// Data directory OpenCode reads. `OPENCODE_HOME` overrides it; otherwise it
 /// follows the XDG data dir (`$XDG_DATA_HOME/opencode`, default
 /// `~/.local/share/opencode`), as documented at

--- a/src/share/fixtures.rs
+++ b/src/share/fixtures.rs
@@ -38,6 +38,7 @@ pub(crate) fn sample_summary() -> Summary {
         agents: Vec::new(),
         skills: Vec::new(),
         limits: None,
+        credits: None,
         modes: crate::model::ModesSummary::default(),
         tools: Vec::new(),
         projects: vec![

--- a/src/ui/charts.rs
+++ b/src/ui/charts.rs
@@ -419,6 +419,107 @@ pub(super) fn limits_chart_lines(
     out
 }
 
+/// CREDITS history: daily AI-credit spend as BY HOUR-style bars, auto-scaled
+/// to the busiest day (credits are a spend quantity, not a utilization
+/// percentage). Historical by design — a ledger of spend that already
+/// happened, never a remaining-quota meter. A zero day on the baseline
+/// renders as a faint dot so "no spend" reads differently from "tiny spend".
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "Chart geometry is display-only."
+)]
+pub(super) fn credits_chart_lines(
+    summary: &Summary,
+    width: u16,
+    body_height: usize,
+) -> Vec<Line<'static>> {
+    let Some(credits) = &summary.credits else {
+        return Vec::new();
+    };
+    let Some((peak_date, peak_value)) = credits.peak else {
+        return Vec::new();
+    };
+    if credits.days.is_empty() || peak_value <= 0.0 {
+        return Vec::new();
+    }
+    let height = body_height.max(1);
+    let half_cells = height * 2;
+    let day_count = credits.days.len();
+    let graph_available = usize::from(width).saturating_sub(7);
+    let chars_per_bar = if graph_available >= day_count * 2 {
+        2
+    } else {
+        1
+    };
+
+    let annotation = format!(
+        "30d total {total} · peak {peak} · {month} {day}",
+        total = utils::format_credits(credits.total),
+        peak = utils::format_credits(peak_value),
+        month = utils::month_abbrev(peak_date.month()),
+        day = peak_date.day(),
+    );
+    let mut out = vec![utils::section_title("CREDITS", &annotation)];
+
+    for row in 0..height {
+        let label = match row {
+            0 => format!("{:>6}", utils::format_credits(peak_value)),
+            _ if row == height / 2 => format!("{:>6}", utils::format_credits(peak_value / 2.0)),
+            _ if row == height - 1 => format!("{:>6}", 0),
+            _ => " ".repeat(6),
+        };
+        let mut spans = vec![
+            Span::styled(label, Style::default().fg(theme::MUTED)),
+            Span::styled("│", Style::default().fg(theme::DIM)),
+        ];
+        let half_bottom = 2 * (height - 1 - row);
+        let half_top = half_bottom + 1;
+        let baseline = row == height - 1;
+        for (_, value) in &credits.days {
+            let level = if *value > 0.0 {
+                ((value / peak_value) * half_cells as f64).round().max(1.0) as usize
+            } else {
+                0
+            };
+            let glyph = if level > half_top {
+                "█"
+            } else if level > half_bottom {
+                "▄"
+            } else if baseline {
+                if *value > 0.0 { "▁" } else { "·" }
+            } else {
+                " "
+            };
+            let color = if *value > 0.0 {
+                theme::GREEN
+            } else {
+                theme::DIM
+            };
+            spans.push(Span::styled(
+                glyph.repeat(chars_per_bar),
+                Style::default().fg(color),
+            ));
+        }
+        out.push(Line::from(spans));
+    }
+
+    let points: Vec<(usize, String)> = [0.0, 0.5, 1.0]
+        .iter()
+        .filter_map(|fraction| {
+            let index = ((day_count.saturating_sub(1)) as f64 * fraction).round() as usize;
+            let (date, _) = credits.days.get(index)?;
+            Some((
+                7 + index * chars_per_bar,
+                format!("{} {}", utils::month_abbrev(date.month()), date.day()),
+            ))
+        })
+        .collect();
+    out.push(axis_label_row(width, &points));
+    out
+}
+
 fn model_daily_values(summary: &Summary, model_name: &str) -> Vec<u64> {
     let usage_by_date = summary
         .model_daily

--- a/src/ui/page.rs
+++ b/src/ui/page.rs
@@ -400,6 +400,7 @@ mod tests {
             claude_dir: std::path::PathBuf::new(),
             codex_dir: std::path::PathBuf::new(),
             agy_dir: None,
+            copilot_dir: None,
             opencode_dir: None,
             cursor: None,
             days: 30,

--- a/src/ui/page.rs
+++ b/src/ui/page.rs
@@ -91,6 +91,18 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
         }
     }
 
+    // CREDITS history is Copilot-only for the same reason LIMITS is
+    // Codex-only: the AI-credit ledger is that provider's own accounting,
+    // and it is deliberately historical.
+    if summary.provider == Provider::Copilot {
+        let chart_width = if two_column { left_u16 } else { width };
+        let credits = charts::credits_chart_lines(summary, chart_width, CHART_BODY);
+        if !credits.is_empty() {
+            lines.extend(credits);
+            lines.push(Line::default());
+        }
+    }
+
     // Per-tab v0.9 sections: SKILLS is Claude-only (attribution is a Claude
     // log feature), MODES renders each provider's own dial. The Total tab
     // shows neither — they are not cross-provider metrics.
@@ -349,6 +361,16 @@ mod tests {
             fast_turns: 0,
             efforts: vec![("xhigh".to_owned(), 93), ("low".to_owned(), 6)],
         };
+        summary.credits = Some(crate::model::CreditsHistory {
+            days: (0..30)
+                .map(|offset| {
+                    let date = time::macros::date!(2026 - 06 - 28) + time::Duration::days(offset);
+                    (date, if offset == 20 { 4.2 } else { 0.4 })
+                })
+                .collect(),
+            total: 15.8,
+            peak: Some((time::macros::date!(2026 - 07 - 18), 4.2)),
+        });
         summary
     }
 
@@ -371,10 +393,17 @@ mod tests {
         assert!(codex.contains("xhigh"));
         assert!(!codex.contains("SKILLS"));
 
+        let copilot = rendered(&v09_summary(Provider::Copilot), 110);
+        assert!(copilot.contains("CREDITS"));
+        assert!(copilot.contains("30d total"));
+        assert!(!copilot.contains("SKILLS"));
+        assert!(!copilot.contains("LIMITS"));
+
         let total = rendered(&v09_summary(Provider::Combined), 110);
         assert!(!total.contains("SKILLS"));
         assert!(!total.contains("LIMITS"));
         assert!(!total.contains("MODES"));
+        assert!(!total.contains("CREDITS"));
     }
 
     /// Narrow terminals stack the sections; the per-tab rules still hold.
@@ -429,9 +458,20 @@ mod tests {
         assert!(codex_page.contains("peak 100%"));
         assert!(codex_page.contains("xhigh"));
 
+        let copilot = report
+            .providers
+            .iter()
+            .find(|summary| summary.provider == Provider::Copilot)
+            .expect("demo should have a Copilot provider");
+        let copilot_page = rendered(copilot, 110);
+        assert!(copilot_page.contains("CREDITS"));
+        assert!(copilot_page.contains("30d total"));
+        assert!(copilot_page.contains("COMPLETION"));
+
         let total_page = rendered(&report.combined, 110);
         assert!(!total_page.contains("SKILLS"));
         assert!(!total_page.contains("LIMITS"));
         assert!(!total_page.contains("MODES"));
+        assert!(!total_page.contains("CREDITS"));
     }
 }

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -31,6 +31,7 @@ pub(super) fn provider_color(provider: Provider) -> Color {
         Provider::Agy => BLUE,
         Provider::OpenCode => PURPLE,
         Provider::Cursor => TEAL,
+        Provider::Copilot => ACCENT,
         Provider::Combined => GOLD,
     }
 }

--- a/src/ui/utils.rs
+++ b/src/ui/utils.rs
@@ -63,6 +63,18 @@ pub(super) fn weekday_index(date: Date) -> u8 {
     }
 }
 
+/// Compact credit formatting: two significant decimals under 10, one under
+/// 100, whole numbers beyond ("0.35", "12.4", "180").
+pub(super) fn format_credits(credits: f64) -> String {
+    if credits < 10.0 {
+        format!("{credits:.2}")
+    } else if credits < 100.0 {
+        format!("{credits:.1}")
+    } else {
+        format!("{credits:.0}")
+    }
+}
+
 pub(super) fn month_abbrev(month: time::Month) -> &'static str {
     match month {
         time::Month::January => "Jan",


### PR DESCRIPTION
Adds GitHub Copilot CLI (`@github/copilot`, the agentic CLI) as an auto-detected provider, reading `~/.copilot/session-state/<uuid>/events.jsonl` locally (override: `--copilot-dir` / `COPILOT_HOME`). No network involved.

## Design

- Tokens come from `session.shutdown` — per-model cumulative totals written on clean exit. `inputTokens` includes `cacheReadTokens` (verified against the CLI's own on-screen totals), so fresh input is the difference; `reasoningTokens` is a subset of output.
- `--resume` appends to the same session and each later exit appends another cumulative shutdown; each shutdown is counted as the component-wise delta since the previous snapshot, dated at its own exit — so a segment inside the analysis window survives even when an earlier exit falls outside it, and cumulatives are never summed. A counter going backwards (CLI update / epoch reset) counts the fresh snapshot in full.
- Sessions that never exit cleanly contribute activity but no tokens until they close; long-lived sessions attribute to the first clean-exit day. Contract documented in docs/copilot.md.
- Tools (deduped by tool-call id), project from session cwd, activity from event timestamps.
- **CREDITS panel** (Copilot tab only): daily AI-credit spend rebuilt from the cumulative `totalNanoAiu` ledger — checkpoints are written even for sessions that never exit cleanly, so credits keep tracking exactly where token data has its gap. Historical by design, never a quota meter.
- **COMPLETION**: turn durations from explicit `assistant.turn_start`/`turn_end` pairs — real boundaries, no heuristics.

## Verification

fmt / clippy (pedantic, zero warnings) / 131 tests incl. per-segment resume attribution, cumulative reset, cache-write-only, cross-session tool ids, malformed-line resilience, dotted-pricing resolution, no-shutdown, and multi-model fixtures. Pre-PR second-model (codex) review applied — see 187e1ac. Schema verified live against CLI 1.0.73 with probe sessions (including a `--resume` cycle); real-data render shows the Copilot tab with exactly the probe sessions' totals and other tabs byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

