### PR TITLE
Release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.0] - 2026-07-29
 
 ### Changed
 
@@ -331,7 +331,7 @@ First public release with the codename system and the shareable stats card.
 Initial npm packaging.
 
 [#36]: https://github.com/miiiiiiich/agent-walker/issues/36
-[Unreleased]: https://github.com/miiiiiiich/agent-walker/compare/v0.12.0...HEAD
+[0.13.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.10.1...v0.11.0
 [0.10.1]: https://github.com/miiiiiiich/agent-walker/releases/tag/v0.10.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-walker"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-walker"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Local AI coding-agent usage dashboard — tokens, cost, projects, autonomy."


### PR DESCRIPTION
Minor release: unified chart density (one char per column, shared chart frame and bar track) plus the audit-label restructuring — one file per chart/section/panel-data responsibility, isolated egress and sanitize boundaries (#47).

- `Cargo.toml` 0.12.0 → 0.13.0, `Cargo.lock` follows
- `CHANGELOG.md`: `[Unreleased]` → `[0.13.0] - 2026-07-29`

After merge: annotated tag `v0.13.0` on main HEAD triggers the release workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)