### PR TITLE
Add third-party acknowledgement and notices

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -113,6 +113,10 @@ Claude Code は既定で**約30日でトランスクリプトを整理する**�
 - Antigravity のログのタイムスタンプはタイムゾーンなし＝ローカル想定。
 - Windows バイナリは 0.3 以降で配布。Windows Terminal / PowerShell で動き、ログは `%USERPROFILE%` から読む。WSL でもそのまま動く（パスは Linux 形式のまま）。
 
+## 謝辞
+
+[ccusage](https://github.com/ccusage/ccusage) は AI コーディングエージェントのローカル利用量トラッキングの先駆者で、agent-walker が扱う問題のいくつかを最初に特定・解決した。[THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES) も参照。
+
 ## ライセンス
 
 MIT または Apache-2.0、好きな方で。

--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ indefinitely; no setting needed.
   Windows Terminal / PowerShell and reads logs from `%USERPROFILE%`. WSL
   installs work too — paths just stay in their Linux form.
 
+## Acknowledgements
+
+[ccusage](https://github.com/ccusage/ccusage) pioneered local usage tracking
+for AI coding agents and first identified and solved problems that
+agent-walker also addresses. See [THIRD_PARTY_NOTICES](THIRD_PARTY_NOTICES).
+
 ## License
 
 MIT or Apache-2.0, at your option.

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,32 @@
+Third-party notices
+===================
+
+No ccusage source code is incorporated in agent-walker. ccusage's copyright
+notice and license are reproduced below in recognition of ccusage and its
+prior work on problems that agent-walker also addresses.
+
+-------------------------------------------------------------------------------
+
+ccusage — https://github.com/ccusage/ccusage
+
+MIT License
+
+Copyright (c) 2025 ryoppippi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,5 +17,7 @@ targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-da
 hosting = "github"
 # Whether to attest build provenance with GitHub Artifact Attestations
 github-attestations = true
+# Extra files to ship inside every release archive
+include = ["THIRD_PARTY_NOTICES"]
 # Publish jobs to run in CI
 publish-jobs = ["npm"]


### PR DESCRIPTION
Addresses #49.

- Add `THIRD_PARTY_NOTICES` with ccusage's copyright notice and the full MIT license text, in recognition of ccusage's prior work on problems agent-walker also addresses. The implementations concerned are identified in the #49 thread.
- Add an acknowledgement and link to ccusage in `README.md` / `README.ja.md`.
- Ship the notice in every distribution: `include = ["THIRD_PARTY_NOTICES"]` in `dist-workspace.toml` covers all five binary release archives and the npm package (verified against the cargo-dist plan); the cargo source package includes it by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)