### PR TITLE
Own the release body and announce releases on X

### DIFF
--- a/.github/scripts/draft_release.py
+++ b/.github/scripts/draft_release.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Render the draft GitHub Release title/body from CHANGELOG.md.
+
+Usage: draft_release.py <tag>            -> body on stdout
+       draft_release.py <tag> --title    -> title on stdout
+
+Exits non-zero if CHANGELOG.md has no section for the tag's version — by
+design: a release without release notes should fail loudly before dist
+builds anything.
+"""
+
+import re
+import sys
+
+REPO = "miiiiiiich/agent-walker"
+
+
+def changelog_section(version: str, changelog: str) -> tuple[str, str]:
+    """Return (date, section body) for the version."""
+    pattern = re.compile(
+        r"^## \[" + re.escape(version) + r"\] - (\S+)\s*\n(.*?)(?=^## \[|^\[|\Z)",
+        re.M | re.S,
+    )
+    m = pattern.search(changelog)
+    if not m:
+        sys.exit(f"CHANGELOG.md has no section for [{version}] — write it before tagging")
+    return m.group(1), m.group(2).strip()
+
+
+def main() -> None:
+    tag = sys.argv[1]
+    version = tag.lstrip("v")
+    with open("CHANGELOG.md") as f:
+        date, section = changelog_section(version, f.read())
+
+    if "--title" in sys.argv[2:]:
+        print(f"{version} - {date}")
+        return
+
+    body = f"""## Release Notes
+
+{section}
+
+## Usage
+
+No install — `npx` / `bunx` fetch the prebuilt binary for your platform:
+
+```sh
+npx agent-walker
+# or
+bunx agent-walker
+```
+
+Prebuilt binaries are attached below. Every artifact carries a [GitHub Artifact Attestation](https://github.com/{REPO}/attestations) — verify with `gh attestation verify <file> --repo {REPO}`.
+"""
+    print(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/tweet_release.py
+++ b/.github/scripts/tweet_release.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Compose and post the release announcement tweet.
+
+Reads release.json ({tag_name, body}) produced by the workflow, builds a
+<=280-char tweet from the Release Notes section, and posts it via the X v2
+API (OAuth 1.0a user context). DRY_RUN=true prints the tweet and exits.
+"""
+
+import json
+import os
+import re
+import sys
+
+MAX_WEIGHT = 280
+URL_WEIGHT = 23  # every URL counts as 23 chars on X
+
+
+def weight(text: str) -> int:
+    # CJK and most non-latin chars count as 2; keep it simple and safe.
+    return sum(2 if ord(c) > 0x10FF else 1 for c in text)
+
+
+def bullets_from(body: str) -> list[str]:
+    # scope to the Release Notes section: strip its header, cut at the next H2
+    body = re.sub(r"^## Release Notes\s*", "", body.strip())
+    body = re.split(r"^## ", body, maxsplit=1, flags=re.M)[0]
+    out = []
+    for m in re.finditer(r"^- (.+?)(?=^[^\s]|\Z)", body, re.M | re.S):
+        text = " ".join(m.group(1).split())  # unwrap hard-wrapped lines
+        text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)  # strip md links
+        text = re.sub(r"https?://\S+", "", text)  # bare URLs would count as 23 on X
+        text = text.replace("`", "").replace("**", "")
+        text = re.sub(r"\s*\(#\d+\)", "", text)  # drop issue/PR refs
+        text = " ".join(text.split())
+        # keep the headline clause, drop the prose tail
+        text = re.split(r"(?<=[.!?]) ", text)[0].rstrip(".")
+        if len(text) > 90:
+            text = text[:89].rstrip() + "…"
+        out.append(text)
+    return out
+
+
+def effective_weight(tweet: str) -> int:
+    # every URL counts as URL_WEIGHT regardless of its real length
+    stripped, n = re.subn(r"https?://\S+", "", tweet)
+    return weight(stripped) + n * URL_WEIGHT
+
+
+def compose(tag: str, body: str) -> str:
+    head = f"agent-walker {tag}"
+    url = f"https://github.com/miiiiiiich/agent-walker/releases/tag/{tag}"
+    budget = MAX_WEIGHT - weight(head) - 2 - (URL_WEIGHT + 2)
+    lines = []
+    for b in bullets_from(body):
+        line = f"・{b}"
+        w = weight(line) + 1
+        if w > budget:
+            if not lines and budget > 40:
+                while weight(line) + 1 > budget:
+                    line = line[:-8] + "…"
+                lines.append(line)
+            break
+        lines.append(line)
+        budget -= w
+
+    def build(ls: list[str]) -> str:
+        parts = [head] + ([""] + ls if ls else []) + ["", url]
+        return "\n".join(parts)
+
+    tweet = build(lines)
+    while lines and effective_weight(tweet) > MAX_WEIGHT:  # belt and braces
+        lines.pop()
+        tweet = build(lines)
+    if effective_weight(tweet) > MAX_WEIGHT:
+        sys.exit(f"tweet still overweight ({effective_weight(tweet)}) with no bullets left")
+    return tweet
+
+
+def main() -> None:
+    with open("release.json") as f:
+        release = json.load(f)
+    tweet = compose(release["tag_name"], release.get("body") or "")
+    print(tweet)
+    print(f"--- effective weight: {effective_weight(tweet)}/280", file=sys.stderr)
+
+    if os.environ.get("DRY_RUN", "").lower() == "true":
+        print("dry run — not posting", file=sys.stderr)
+        return
+
+    keys = ["X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_TOKEN_SECRET"]
+    missing = [k for k in keys if not os.environ.get(k)]
+    if missing:
+        sys.exit(f"missing secrets: {', '.join(missing)}")
+
+    from requests_oauthlib import OAuth1Session
+
+    session = OAuth1Session(
+        os.environ["X_API_KEY"],
+        client_secret=os.environ["X_API_SECRET"],
+        resource_owner_key=os.environ["X_ACCESS_TOKEN"],
+        resource_owner_secret=os.environ["X_ACCESS_TOKEN_SECRET"],
+    )
+    try:
+        resp = session.post("https://api.x.com/2/tweets", json={"text": tweet}, timeout=30)
+    except Exception as e:  # noqa: BLE001 — network stall must not hang the job
+        sys.exit(f"post failed: {e}")
+    if resp.status_code != 201:
+        sys.exit(f"post failed: {resp.status_code} {resp.text}")
+    print(f"posted: {resp.json()['data']['id']}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,44 @@
+name: Draft release
+
+# Creates the draft GitHub Release with a body rendered from CHANGELOG.md.
+# Wired into release.yml as a dist custom plan-job (dist-workspace.toml:
+# plan-jobs = ["./draft-release"]), so builds wait for the draft and a
+# missing CHANGELOG section stops the release before anything is built.
+# dist (create-release = false) uploads artifacts into this draft and
+# undrafts it once everything is attached.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    # release.yml also runs on pull_request (plan only) — only draft on tags
+    if: startsWith(github.ref, 'refs/tags/')
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Create draft release with notes from CHANGELOG
+        run: |
+          if EXISTING=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null); then
+            if [ "$EXISTING" = "true" ]; then
+              echo "draft for $TAG already exists (re-run); leaving it as is"
+              exit 0
+            fi
+            echo "a published release for $TAG already exists — refusing to touch it" >&2
+            exit 1
+          fi
+          python3 .github/scripts/draft_release.py "$TAG" > notes.md
+          TITLE="$(python3 .github/scripts/draft_release.py "$TAG" --title)"
+          PRERELEASE_FLAG=""
+          case "${TAG%%+*}" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          gh release create "$TAG" --draft $PRERELEASE_FLAG --title "$TITLE" --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@
 # * uploads those artifacts to temporary workflow zip
 # * on success, uploads the artifacts to a GitHub Release
 #
-# Note that the GitHub Release will be created with a generated
-# title/body based on your changelogs.
+# Note that a GitHub Release with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
 
 name: Release
 permissions:
@@ -87,12 +87,17 @@ jobs:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
 
+  custom-draft-release:
+    uses: ./.github/workflows/draft-release.yml
+    secrets: inherit
+
   # Build and packages all the platform-specific things
   build-local-artifacts:
     name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
+      - custom-draft-release
     if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
     strategy:
       fail-fast: false
@@ -277,14 +282,12 @@ jobs:
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          # If we're editing a release in place, we need to upload things ahead of time
+          gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
 
   publish-npm:
     needs:

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -1,0 +1,54 @@
+name: Tweet release
+
+# release.yml publishes the release with the default GITHUB_TOKEN, and
+# GitHub suppresses events caused by that token — a `release: published`
+# trigger would never fire. So we chain on the Release workflow's
+# completion instead and resolve the tag from its run.
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to tweet (e.g. v0.13.1)"
+        required: true
+      dry_run:
+        description: "Print the tweet without posting"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  tweet:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install requests-oauthlib==2.0.0
+      - name: Resolve release payload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
+        run: |
+          gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
+            --jq '{tag_name, body, draft}' > release.json
+          if [ "$(jq -r .draft release.json)" = "true" ]; then
+            echo "release $TAG is still a draft; not tweeting"
+            exit 1
+          fi
+      - name: Compose and post
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+        run: python .github/scripts/tweet_release.py

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,17 +7,24 @@ members = ["cargo:."]
 cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
-# The installers to generate for each app (npx / bunx only)
+# The installers to generate for each app
 installers = ["npm"]
-# A namespace to use when publishing this package to the npm registry
+# The npm package should have this name
 npm-package = "agent-walker"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Where to host releases
 hosting = "github"
-# Whether to attest build provenance with GitHub Artifact Attestations
+# Whether dist should create a Github Release or use an existing draft
+create-release = false
+# Whether to enable GitHub Attestations
 github-attestations = true
-# Extra files to ship inside every release archive
+# Extra static files to include in each App (path relative to this Cargo.toml's dir)
 include = ["THIRD_PARTY_NOTICES"]
 # Publish jobs to run in CI
 publish-jobs = ["npm"]
+# Plan jobs to run in CI
+plan-jobs = ["./draft-release"]
+
+[dist.github-custom-runners]
+x86_64-apple-darwin = "macos-15"


### PR DESCRIPTION
## Why

The GitHub Release body was fully generated by cargo-dist: a generic "install into your npm project" section (which leads a CLI user to `command not found`) and a long attestation how-to. dist has no option to change that text, so this PR takes the body back and, while touching the release flow, adds an automatic release tweet.

## Changes

- **Release body is now ours** (`create-release = false`): a custom plan-job (`draft-release.yml` + `draft_release.py`) creates the draft release with notes rendered from the CHANGELOG section, npx/bunx usage matching the README, and a one-line attestation pointer. dist uploads artifacts into that draft and publishes it. Builds wait on the draft via `needs`, so tagging without a CHANGELOG entry stops the release before any build runs.
- **Automatic release tweet** (`tweet-release.yml` + `tweet_release.py`): fires when the Release workflow completes (a `release: published` trigger would never fire because GITHUB_TOKEN events don't start workflows). Composes ≤280-weight text from the Release Notes section. Needs four `X_*` repo secrets; until they exist the job fails visibly without affecting the release.
- **Faster builds**: `x86_64-apple-darwin` moves from the Intel runner (8 min, the bottleneck) to `macos-15` cross-compiling — expected ~6.5 min wall-clock instead of ~9.5.

## Test

- `draft_release.py` and `tweet_release.py` verified locally against the real v0.13.1 / v0.9.0 release data plus synthetic edge cases (bare URLs, nested bullets, missing CHANGELOG section fails loudly).
- `dist plan` confirms the new runner assignment; workflow YAML parses.
- Two codex review rounds; all High/Medium findings addressed.
- First real end-to-end run will be the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)