### PR TITLE
Own the release body and announce releases on X

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!--
+Thanks for contributing to agent-walker!
+
+- Keep the title descriptive; the diff carries the details.
+- Reference related issues with #NNN.
+- fmt / clippy / tests are enforced by CI — no need to attest here.
+-->
+
+## Summary
+
+<!-- What does this change do, and why? -->
+
+## Test Plan
+
+<!-- How was it verified? -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -15,30 +18,38 @@ jobs:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: 1.95.0
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo test --all-targets
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@master
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
           toolchain: 1.95.0
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2
       - run: cargo fmt --check
       - run: cargo clippy --all-targets --all-features -- -D warnings
 
   audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: taiki-e/install-action@cargo-audit
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: taiki-e/install-action@b20dedce73af6905cdc30d6611090c9b67557c8d # v2
+        with:
+          tool: cargo-audit
       - run: cargo audit
 
   release-scripts:
@@ -47,10 +58,25 @@ jobs:
       run:
         working-directory: scripts
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v10.0.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
       - run: uv sync --locked
       - run: uv run pytest -q
       - run: uv run ruff check .
       - run: uv run ruff format --check .
       - run: uv run pyright
+
+  zizmor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
+      # release.yml is dist-generated and owned by cargo-dist upstream —
+      # excluded here because its findings are not ours to fix
+      - run: |
+          git ls-files '.github/workflows/*.yml' | grep -v '/release\.yml$' \
+            | xargs uvx --from 'zizmor==1.29.0' zizmor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,17 @@ jobs:
       - uses: actions/checkout@v6
       - uses: taiki-e/install-action@cargo-audit
       - run: cargo audit
+
+  release-scripts:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: scripts
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v10
+      - run: uv sync --locked
+      - run: uv run pytest -q
+      - run: uv run ruff check .
+      - run: uv run ruff format --check .
+      - run: uv run pyright

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
         working-directory: scripts
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v10
+      - uses: astral-sh/setup-uv@v10.0.0
       - run: uv sync --locked
       - run: uv run pytest -q
       - run: uv run ruff check .

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,44 @@
+name: Draft release
+
+# Creates the draft GitHub Release with a body rendered from CHANGELOG.md.
+# Wired into release.yml as a dist custom plan-job (dist-workspace.toml:
+# plan-jobs = ["./draft-release"]), so builds wait for the draft and a
+# missing CHANGELOG section stops the release before anything is built.
+# dist (create-release = false) uploads artifacts into this draft and
+# undrafts it once everything is attached.
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+
+jobs:
+  draft:
+    runs-on: ubuntu-latest
+    # release.yml also runs on pull_request (plan only) — only draft on tags
+    if: startsWith(github.ref, 'refs/tags/')
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.ref_name }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Create draft release with notes from CHANGELOG
+        run: |
+          if EXISTING=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null); then
+            if [ "$EXISTING" = "true" ]; then
+              echo "draft for $TAG already exists (re-run); leaving it as is"
+              exit 0
+            fi
+            echo "a published release for $TAG already exists — refusing to touch it" >&2
+            exit 1
+          fi
+          python3 scripts/draft_release.py "$TAG" > notes.md
+          TITLE="$(python3 scripts/draft_release.py "$TAG" --title)"
+          PRERELEASE_FLAG=""
+          case "${TAG%%+*}" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
+          gh release create "$TAG" --draft $PRERELEASE_FLAG --title "$TITLE" --notes-file notes.md

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -29,7 +29,12 @@ jobs:
         run: |
           if EXISTING=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null); then
             if [ "$EXISTING" = "true" ]; then
-              echo "draft for $TAG already exists (re-run); leaving it as is"
+              # re-run: clear partially uploaded assets so the host step's
+              # gh release upload doesn't collide with stale names
+              echo "draft for $TAG already exists (re-run); clearing stale assets"
+              gh release view "$TAG" --json assets --jq '.assets[].name' | while IFS= read -r asset; do
+                gh release delete-asset "$TAG" "$asset" -y
+              done
               exit 0
             fi
             echo "a published release for $TAG already exists — refusing to touch it" >&2

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -22,7 +22,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       TAG: ${{ github.ref_name }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
       - name: Create draft release with notes from CHANGELOG

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -29,12 +29,7 @@ jobs:
         run: |
           if EXISTING=$(gh release view "$TAG" --json isDraft --jq .isDraft 2>/dev/null); then
             if [ "$EXISTING" = "true" ]; then
-              # re-run: clear partially uploaded assets so the host step's
-              # gh release upload doesn't collide with stale names
-              echo "draft for $TAG already exists (re-run); clearing stale assets"
-              gh release view "$TAG" --json assets --jq '.assets[].name' | while IFS= read -r asset; do
-                gh release delete-asset "$TAG" "$asset" -y
-              done
+              echo "draft for $TAG already exists (re-run); leaving it as is"
               exit 0
             fi
             echo "a published release for $TAG already exists — refusing to touch it" >&2
@@ -42,8 +37,11 @@ jobs:
           fi
           python3 scripts/draft_release.py "$TAG" > notes.md
           TITLE="$(python3 scripts/draft_release.py "$TAG" --title)"
+          # prerelease markers live in the version component, not the
+          # package prefix of package-qualified tags (agent-walker/0.14.0)
+          VERSION="${TAG##*/}"
           PRERELEASE_FLAG=""
-          case "${TAG%%+*}" in
+          case "${VERSION%%+*}" in
             *-*) PRERELEASE_FLAG="--prerelease" ;;
           esac
           gh release create "$TAG" --draft $PRERELEASE_FLAG --title "$TITLE" --notes-file notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,8 +10,8 @@
 # * uploads those artifacts to temporary workflow zip
 # * on success, uploads the artifacts to a GitHub Release
 #
-# Note that the GitHub Release will be created with a generated
-# title/body based on your changelogs.
+# Note that a GitHub Release with this tag is assumed to exist as a draft
+# with the appropriate title/body, and will be undrafted for you.
 
 name: Release
 permissions:
@@ -87,12 +87,17 @@ jobs:
           name: artifacts-plan-dist-manifest
           path: plan-dist-manifest.json
 
+  custom-draft-release:
+    uses: ./.github/workflows/draft-release.yml
+    secrets: inherit
+
   # Build and packages all the platform-specific things
   build-local-artifacts:
     name: build-local-artifacts (${{ join(matrix.targets, ', ') }})
     # Let the initial task tell us to not run (currently very blunt)
     needs:
       - plan
+      - custom-draft-release
     if: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix.include != null && (needs.plan.outputs.publishing == 'true' || fromJson(needs.plan.outputs.val).ci.github.pr_run_mode == 'upload') }}
     strategy:
       fail-fast: false
@@ -277,14 +282,12 @@ jobs:
       - name: Create GitHub Release
         env:
           PRERELEASE_FLAG: "${{ fromJson(steps.host.outputs.manifest).announcement_is_prerelease && '--prerelease' || '' }}"
-          ANNOUNCEMENT_TITLE: "${{ fromJson(steps.host.outputs.manifest).announcement_title }}"
-          ANNOUNCEMENT_BODY: "${{ fromJson(steps.host.outputs.manifest).announcement_github_body }}"
           RELEASE_COMMIT: "${{ github.sha }}"
         run: |
-          # Write and read notes from a file to avoid quoting breaking things
-          echo "$ANNOUNCEMENT_BODY" > $RUNNER_TEMP/notes.txt
+          # If we're editing a release in place, we need to upload things ahead of time
+          gh release upload "${{ needs.plan.outputs.tag }}" artifacts/*
 
-          gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
+          gh release edit "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --draft=false
 
   publish-npm:
     needs:

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -82,14 +82,19 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       TAG: ${{ github.event.workflow_run.head_branch }}
+      # assets uploaded by a retry always post-date the failed run, so
+      # deleting only what predates it can never race a concurrent re-run
+      # into publishing a release with missing files
+      CUTOFF: ${{ github.event.workflow_run.updated_at }}
     steps:
-      - name: Clear stale assets from the draft
+      - name: Clear assets that predate the failed run
         run: |
           if [ "$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft --jq .isDraft 2>/dev/null)" != "true" ]; then
             echo "no draft for $TAG; nothing to clean"
             exit 0
           fi
-          gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | while IFS= read -r asset; do
+          gh release view "$TAG" --repo "${{ github.repository }}" --json assets \
+            --jq ".assets[] | select(.createdAt < \"$CUTOFF\") | .name" | while IFS= read -r asset; do
             echo "deleting stale asset: $asset"
             gh release delete-asset "$TAG" "$asset" -y --repo "${{ github.repository }}"
           done

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -35,11 +35,14 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
-      # deliberately the default branch, not the tag's commit: this job
-      # holds the X credentials, and tag-controlled code must not run
-      # with them. The script is CI-gated on main; minor version skew
-      # against the tag is the accepted lesser risk.
+      # pinned to the default branch on every trigger: this job holds
+      # the X credentials, and neither tag-controlled nor
+      # branch-dispatched code may run with them. The script is
+      # CI-gated on main; version skew against the tag is the accepted
+      # lesser risk.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -1,9 +1,11 @@
-name: Tweet release
+name: Post release
 
-# release.yml publishes the release with the default GITHUB_TOKEN, and
-# GitHub suppresses events caused by that token — a `release: published`
-# trigger would never fire. So we chain on the Release workflow's
-# completion instead and resolve the tag from its run.
+# Runs after the Release workflow: tweet on success, clear stale draft
+# assets on failure so any kind of re-run uploads cleanly.
+#
+# This chains on workflow_run because release.yml publishes with the
+# default GITHUB_TOKEN, and GitHub suppresses events caused by that
+# token — a `release: published` trigger would never fire.
 
 on:
   workflow_run:
@@ -58,3 +60,31 @@ jobs:
           X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
           X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
         run: python scripts/tweet_release.py
+
+  # a failed host step can leave partially uploaded assets on the draft;
+  # cleared here (not in the draft job) because "re-run failed jobs"
+  # skips jobs that already succeeded
+  clean-draft:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'workflow_run' &&
+      (github.event.workflow_run.conclusion == 'failure' ||
+       github.event.workflow_run.conclusion == 'cancelled') &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      TAG: ${{ github.event.workflow_run.head_branch }}
+    steps:
+      - name: Clear stale assets from the draft
+        run: |
+          if [ "$(gh release view "$TAG" --repo "${{ github.repository }}" --json isDraft --jq .isDraft 2>/dev/null)" != "true" ]; then
+            echo "no draft for $TAG; nothing to clean"
+            exit 0
+          fi
+          gh release view "$TAG" --repo "${{ github.repository }}" --json assets --jq '.assets[].name' | while IFS= read -r asset; do
+            echo "deleting stale asset: $asset"
+            gh release delete-asset "$TAG" "$asset" -y --repo "${{ github.repository }}"
+          done

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -35,7 +35,12 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
+      # workflow_run checkouts default to the default-branch tip, not the
+      # released commit — pin to the triggering run's sha (empty on
+      # workflow_dispatch, which then falls back to the default branch)
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -7,7 +7,9 @@ name: Post release
 # default GITHUB_TOKEN, and GitHub suppresses events caused by that
 # token — a `release: published` trigger would never fire.
 
-on:
+# deliberate workflow_run: gated to same-repo tag pushes, secrets only
+# meet code from the pinned default branch
+on: # zizmor: ignore[dangerous-triggers]
   workflow_run:
     workflows: [Release]
     types: [completed]
@@ -40,10 +42,11 @@ jobs:
       # branch-dispatched code may run with them. The script is
       # CI-gated on main; version skew against the tag is the accepted
       # lesser risk.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: ${{ github.event.repository.default_branch }}
-      - uses: actions/setup-python@v5
+          persist-credentials: false
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -53,7 +53,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
         run: |
-          gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
+          # package-qualified tags contain a slash, which must not become
+          # an extra path segment
+          TAG_PATH=$(jq -rn --arg t "$TAG" '$t|@uri')
+          gh api "repos/${{ github.repository }}/releases/tags/$TAG_PATH" \
             --jq '{tag_name, body, draft}' > release.json
           if [ "$(jq -r .draft release.json)" = "true" ]; then
             echo "release $TAG is still a draft; not tweeting"
@@ -95,10 +98,12 @@ jobs:
             echo "no draft for $TAG; nothing to clean"
             exit 0
           fi
-          # only names dist actually produces (platform archives +
-          # checksums, npm package, manifest, source tarball) — anything
-          # else on the draft was curated by a human and is not ours
-          DIST_NAMES='^(agent-walker-.+\.(tar\.xz|zip)(\.sha256)?|agent-walker-npm-package\.tar\.gz|dist-manifest\.json|sha256\.sum|source\.tar\.gz(\.sha256)?)$'
+          # only names dist actually produces — platform archives are
+          # pinned to the configured target triples (keep in sync with
+          # dist-workspace.toml) so curated archives like
+          # agent-walker-notes.zip survive recovery
+          TRIPLES='aarch64-apple-darwin|aarch64-unknown-linux-gnu|x86_64-unknown-linux-gnu|x86_64-pc-windows-msvc'
+          DIST_NAMES="^(agent-walker-($TRIPLES)\\.(tar\\.xz|zip)(\\.sha256)?|agent-walker-npm-package\\.tar\\.gz|dist-manifest\\.json|sha256\\.sum|source\\.tar\\.gz(\\.sha256)?)$"
           gh release view "$TAG" --repo "${{ github.repository }}" --json assets \
             --jq ".assets[] | select(.createdAt < \"$CUTOFF\" and (.name | test(\"$DIST_NAMES\"))) | .name" | while IFS= read -r asset; do
             echo "deleting stale asset: $asset"

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -35,12 +35,11 @@ jobs:
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_repository.full_name == github.repository)
     steps:
-      # workflow_run checkouts default to the default-branch tip, not the
-      # released commit — pin to the triggering run's sha (empty on
-      # workflow_dispatch, which then falls back to the default branch)
+      # deliberately the default branch, not the tag's commit: this job
+      # holds the X credentials, and tag-controlled code must not run
+      # with them. The script is CI-gated on main; minor version skew
+      # against the tag is the accepted lesser risk.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
@@ -93,10 +92,12 @@ jobs:
             echo "no draft for $TAG; nothing to clean"
             exit 0
           fi
-          # dist artifacts all carry the app-name prefix; anything else on
-          # the draft was curated by a human and is not ours to delete
+          # only names dist actually produces (platform archives +
+          # checksums, npm package, manifest, source tarball) — anything
+          # else on the draft was curated by a human and is not ours
+          DIST_NAMES='^(agent-walker-.+\.(tar\.xz|zip)(\.sha256)?|agent-walker-npm-package\.tar\.gz|dist-manifest\.json|sha256\.sum|source\.tar\.gz(\.sha256)?)$'
           gh release view "$TAG" --repo "${{ github.repository }}" --json assets \
-            --jq ".assets[] | select(.createdAt < \"$CUTOFF\" and (.name | startswith(\"agent-walker\"))) | .name" | while IFS= read -r asset; do
+            --jq ".assets[] | select(.createdAt < \"$CUTOFF\" and (.name | test(\"$DIST_NAMES\"))) | .name" | while IFS= read -r asset; do
             echo "deleting stale asset: $asset"
             gh release delete-asset "$TAG" "$asset" -y --repo "${{ github.repository }}"
           done

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -1,0 +1,60 @@
+name: Tweet release
+
+# release.yml publishes the release with the default GITHUB_TOKEN, and
+# GitHub suppresses events caused by that token — a `release: published`
+# trigger would never fire. So we chain on the Release workflow's
+# completion instead and resolve the tag from its run.
+
+on:
+  workflow_run:
+    workflows: [Release]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to tweet (e.g. v0.13.1)"
+        required: true
+      dry_run:
+        description: "Print the tweet without posting"
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  tweet:
+    runs-on: ubuntu-latest
+    # Release also runs (plan-only, successfully) on pull_request — only tag
+    # pushes from this repo may tweet
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_repository.full_name == github.repository)
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: pip install requests-oauthlib==2.0.0
+      - name: Resolve release payload
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.event.workflow_run.head_branch }}
+        run: |
+          gh api "repos/${{ github.repository }}/releases/tags/$TAG" \
+            --jq '{tag_name, body, draft}' > release.json
+          if [ "$(jq -r .draft release.json)" = "true" ]; then
+            echo "release $TAG is still a draft; not tweeting"
+            exit 1
+          fi
+      - name: Compose and post
+        env:
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run && 'true' || 'false' }}
+          X_API_KEY: ${{ secrets.X_API_KEY }}
+          X_API_SECRET: ${{ secrets.X_API_SECRET }}
+          X_ACCESS_TOKEN: ${{ secrets.X_ACCESS_TOKEN }}
+          X_ACCESS_TOKEN_SECRET: ${{ secrets.X_ACCESS_TOKEN_SECRET }}
+        run: python scripts/tweet_release.py

--- a/.github/workflows/tweet-release.yml
+++ b/.github/workflows/tweet-release.yml
@@ -93,8 +93,10 @@ jobs:
             echo "no draft for $TAG; nothing to clean"
             exit 0
           fi
+          # dist artifacts all carry the app-name prefix; anything else on
+          # the draft was curated by a human and is not ours to delete
           gh release view "$TAG" --repo "${{ github.repository }}" --json assets \
-            --jq ".assets[] | select(.createdAt < \"$CUTOFF\") | .name" | while IFS= read -r asset; do
+            --jq ".assets[] | select(.createdAt < \"$CUTOFF\" and (.name | startswith(\"agent-walker\"))) | .name" | while IFS= read -r asset; do
             echo "deleting stale asset: $asset"
             gh release delete-asset "$TAG" "$asset" -y --repo "${{ github.repository }}"
           done

--- a/.gitignore
+++ b/.gitignore
@@ -326,3 +326,9 @@ token.json
 ### Local agent notes (never tracked — operational meta stays out of the public repo)
 AGENTS.md
 CLAUDE.md
+
+### Python release scripts (scripts/)
+scripts/.venv/
+__pycache__/
+.pytest_cache/
+.ruff_cache/

--- a/README.ja.md
+++ b/README.ja.md
@@ -39,7 +39,7 @@ gh attestation verify agent-walker-aarch64-apple-darwin.tar.xz -R miiiiiiich/age
 
 ## 使う
 
-インストール不要 — `npx` / `bunx` がプラットフォーム（macOS arm64/x64・Linux arm64/x64 GNU・Windows x64）に合ったバイナリを取ってきて実行：
+インストール不要 — `npx` / `bunx` がプラットフォーム（macOS Apple Silicon・Linux arm64/x64 GNU・Windows x64）に合ったバイナリを取ってきて実行：
 
 ```sh
 npx agent-walker

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ gh attestation verify agent-walker-aarch64-apple-darwin.tar.xz -R miiiiiiich/age
 ## Use
 
 No install — `npx` / `bunx` fetch the prebuilt binary for your platform
-(macOS arm64/x64, Linux arm64/x64 GNU, Windows x64) and run it:
+(macOS Apple Silicon, Linux arm64/x64 GNU, Windows x64) and run it:
 
 ```sh
 npx agent-walker

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -7,17 +7,24 @@ members = ["cargo:."]
 cargo-dist-version = "0.32.0"
 # CI backends to support
 ci = "github"
-# The installers to generate for each app (npx / bunx only)
+# The installers to generate for each app
 installers = ["npm"]
-# A namespace to use when publishing this package to the npm registry
+# The npm package should have this name
 npm-package = "agent-walker"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-pc-windows-msvc", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Where to host releases
 hosting = "github"
-# Whether to attest build provenance with GitHub Artifact Attestations
+# Whether dist should create a Github Release or use an existing draft
+create-release = false
+# Whether to enable GitHub Attestations
 github-attestations = true
-# Extra files to ship inside every release archive
+# Extra static files to include in each App (path relative to this Cargo.toml's dir)
 include = ["THIRD_PARTY_NOTICES"]
 # Publish jobs to run in CI
 publish-jobs = ["npm"]
+# Plan jobs to run in CI
+plan-jobs = ["./draft-release"]
+
+[dist.github-custom-runners]
+x86_64-apple-darwin = "macos-15"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -12,7 +12,7 @@ installers = ["npm"]
 # The npm package should have this name
 npm-package = "agent-walker"
 # Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
+targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "x86_64-pc-windows-msvc"]
 # Where to host releases
 hosting = "github"
 # Whether dist should create a Github Release or use an existing draft
@@ -25,6 +25,3 @@ include = ["THIRD_PARTY_NOTICES"]
 publish-jobs = ["npm"]
 # Plan jobs to run in CI
 plan-jobs = ["./draft-release"]
-
-[dist.github-custom-runners]
-x86_64-apple-darwin = "macos-15"

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -45,7 +45,7 @@ npx agent-walker
 bunx agent-walker
 ```
 
-Prebuilt binaries are attached below. Every artifact carries a [GitHub Artifact Attestation](https://github.com/{REPO}/attestations) — verify with `gh attestation verify <file> --repo {REPO}`.
+Prebuilt binaries are attached below, each carrying a [GitHub Artifact Attestation](https://github.com/{REPO}/attestations) — verify with `gh attestation verify <file> --repo {REPO}`.
 """
     print(body)
 

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -19,7 +19,27 @@ def changelog_section(version: str, changelog: str) -> tuple[str, str]:
 
 def version_from(tag: str) -> str:
     # dist also fires on package-qualified tags like "agent-walker/0.14.0"
-    return tag.rsplit("/", 1)[-1].lstrip("v")
+    package, _, version = tag.rpartition("/")
+    if package and package != "agent-walker":
+        sys.exit(f"tag {tag} names a package this workspace does not ship")
+    return version.lstrip("v")
+
+
+def usage(version: str) -> str:
+    if "-" in version.split("+", 1)[0]:
+        # prereleases are not published to npm (dist skips publish-npm),
+        # so unversioned npx/bunx would silently run the latest stable
+        return (
+            "This is a prerelease — it is not published to npm. "
+            "Download the platform binary from the assets below."
+        )
+    return """No install — `npx` / `bunx` fetch the prebuilt binary for your platform:
+
+```sh
+npx agent-walker
+# or
+bunx agent-walker
+```"""
 
 
 def main() -> None:
@@ -37,13 +57,7 @@ def main() -> None:
 
 ## Usage
 
-No install — `npx` / `bunx` fetch the prebuilt binary for your platform:
-
-```sh
-npx agent-walker
-# or
-bunx agent-walker
-```
+{usage(version)}
 
 Prebuilt binaries are attached below, each carrying a [GitHub Artifact Attestation](https://github.com/{REPO}/attestations) — verify with `gh attestation verify <file> --repo {REPO}`.
 """

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 REPO = "miiiiiiich/agent-walker"
 CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+CARGO_TOML = Path(__file__).resolve().parents[1] / "Cargo.toml"
 
 
 def changelog_section(version: str, changelog: str) -> tuple[str, str]:
@@ -26,6 +27,19 @@ def version_from(tag: str) -> str:
     return tag.rsplit("/", 1)[-1].lstrip("v")
 
 
+def check_version_matches(version: str, cargo_toml: str) -> None:
+    # mirror dist plan's tag-version validation so a tag plan would
+    # reject can never leave a dangling draft behind
+    m = re.search(r'^version\s*=\s*"([^"]+)"', cargo_toml, re.MULTILINE)
+    if not m:
+        sys.exit("Cargo.toml has no package version")
+    if version != m.group(1):
+        sys.exit(
+            f"tag version {version} does not match Cargo.toml version "
+            f"{m.group(1)} — did the release PR merge?"
+        )
+
+
 def usage(version: str) -> str:
     if "-" in version.split("+", 1)[0]:
         # prereleases are not published to npm (dist skips publish-npm),
@@ -46,6 +60,7 @@ bunx agent-walker
 def main() -> None:
     tag = sys.argv[1]
     version = version_from(tag)
+    check_version_matches(version, CARGO_TOML.read_text())
     date, section = changelog_section(version, CHANGELOG.read_text())
 
     if "--title" in sys.argv[2:]:

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -17,9 +17,14 @@ def changelog_section(version: str, changelog: str) -> tuple[str, str]:
     return m.group(1), m.group(2).strip()
 
 
+def version_from(tag: str) -> str:
+    # dist also fires on package-qualified tags like "agent-walker/0.14.0"
+    return tag.rsplit("/", 1)[-1].lstrip("v")
+
+
 def main() -> None:
     tag = sys.argv[1]
-    version = tag.lstrip("v")
+    version = version_from(tag)
     date, section = changelog_section(version, CHANGELOG.read_text())
 
     if "--title" in sys.argv[2:]:

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -7,8 +7,10 @@ CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
 
 
 def changelog_section(version: str, changelog: str) -> tuple[str, str]:
+    # a section ends at the next version heading or at the footer's
+    # link-reference definitions — not at any body line starting with "["
     pattern = re.compile(
-        r"^## \[" + re.escape(version) + r"\] - (\S+)\s*\n(.*?)(?=^## \[|^\[|\Z)",
+        r"^## \[" + re.escape(version) + r"\] - (\S+)\s*\n(.*?)(?=^## \[|^\[[^\]]+\]:|\Z)",
         re.MULTILINE | re.DOTALL,
     )
     m = pattern.search(changelog)
@@ -18,11 +20,10 @@ def changelog_section(version: str, changelog: str) -> tuple[str, str]:
 
 
 def version_from(tag: str) -> str:
-    # dist also fires on package-qualified tags like "agent-walker/0.14.0"
-    package, _, version = tag.rpartition("/")
-    if package and package != "agent-walker":
-        sys.exit(f"tag {tag} names a package this workspace does not ship")
-    return version.lstrip("v")
+    # dist accepts arbitrary tag prefixes (agent-walker/0.14.0,
+    # releases/v1.0.0 — verified against `dist plan`); only the version
+    # component matters here
+    return tag.rsplit("/", 1)[-1].lstrip("v")
 
 
 def usage(version: str) -> str:

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -1,0 +1,49 @@
+import re
+import sys
+from pathlib import Path
+
+REPO = "miiiiiiich/agent-walker"
+CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+
+
+def changelog_section(version: str, changelog: str) -> tuple[str, str]:
+    pattern = re.compile(
+        r"^## \[" + re.escape(version) + r"\] - (\S+)\s*\n(.*?)(?=^## \[|^\[|\Z)",
+        re.MULTILINE | re.DOTALL,
+    )
+    m = pattern.search(changelog)
+    if not m:
+        sys.exit(f"CHANGELOG.md has no section for [{version}] — write it before tagging")
+    return m.group(1), m.group(2).strip()
+
+
+def main() -> None:
+    tag = sys.argv[1]
+    version = tag.lstrip("v")
+    date, section = changelog_section(version, CHANGELOG.read_text())
+
+    if "--title" in sys.argv[2:]:
+        print(f"{version} - {date}")
+        return
+
+    body = f"""## Release Notes
+
+{section}
+
+## Usage
+
+No install — `npx` / `bunx` fetch the prebuilt binary for your platform:
+
+```sh
+npx agent-walker
+# or
+bunx agent-walker
+```
+
+Prebuilt binaries are attached below. Every artifact carries a [GitHub Artifact Attestation](https://github.com/{REPO}/attestations) — verify with `gh attestation verify <file> --repo {REPO}`.
+"""
+    print(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "release-scripts"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = ["requests-oauthlib>=2.0.0"]
+
+[dependency-groups]
+dev = ["pytest>=8", "ruff>=0.8", "pyright>=1.1.390"]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.pyright]
+venvPath = "."
+venv = ".venv"

--- a/scripts/tests/test_draft_release.py
+++ b/scripts/tests/test_draft_release.py
@@ -1,6 +1,14 @@
 import pytest
 
-from draft_release import changelog_section, usage, version_from
+from draft_release import changelog_section, check_version_matches, usage, version_from
+
+CARGO_TOML = """[package]
+name = "agent-walker"
+version = "1.2.0"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+"""
 
 CHANGELOG = """# Changelog
 
@@ -76,6 +84,13 @@ def test_inline_links_do_not_truncate_section():
     _, section = changelog_section("1.2.0", CHANGELOG)
     assert "Migration guide" in section
     assert "a bug" in section
+
+
+def test_version_match_against_cargo_toml():
+    check_version_matches("1.2.0", CARGO_TOML)
+    with pytest.raises(SystemExit) as e:
+        check_version_matches("1.3.0", CARGO_TOML)
+    assert "1.3.0" in str(e.value) and "1.2.0" in str(e.value)
 
 
 def test_usage_stable_vs_prerelease():

--- a/scripts/tests/test_draft_release.py
+++ b/scripts/tests/test_draft_release.py
@@ -17,6 +17,8 @@ CHANGELOG = """# Changelog
 - feature one, wrapped across
   two lines (#42)
 
+[Migration guide](https://example.com/migrate) for the breaking parts.
+
 ### Fixed
 
 - a bug
@@ -64,10 +66,16 @@ def test_version_from_tag_formats():
     assert version_from("agent-walker/v0.14.0") == "0.14.0"
 
 
-def test_version_from_rejects_foreign_package():
-    with pytest.raises(SystemExit) as e:
-        version_from("other/0.13.1")
-    assert "other/0.13.1" in str(e.value)
+def test_version_from_arbitrary_prefixes():
+    # dist accepts any prefix (verified against `dist plan`)
+    assert version_from("releases/v0.14.0") == "0.14.0"
+    assert version_from("other/0.14.0") == "0.14.0"
+
+
+def test_inline_links_do_not_truncate_section():
+    _, section = changelog_section("1.2.0", CHANGELOG)
+    assert "Migration guide" in section
+    assert "a bug" in section
 
 
 def test_usage_stable_vs_prerelease():

--- a/scripts/tests/test_draft_release.py
+++ b/scripts/tests/test_draft_release.py
@@ -1,0 +1,57 @@
+import pytest
+
+from draft_release import changelog_section
+
+CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+### Added
+
+- something in flight
+
+## [1.2.0] - 2026-08-01
+
+### Added
+
+- feature one, wrapped across
+  two lines (#42)
+
+### Fixed
+
+- a bug
+
+## [1.1.0] - 2026-07-01
+
+### Changed
+
+- older entry
+
+[1.2.0]: https://example.com/compare/v1.1.0...v1.2.0
+[1.1.0]: https://example.com/compare/v1.0.0...v1.1.0
+"""
+
+
+def test_extracts_date_and_section():
+    date, section = changelog_section("1.2.0", CHANGELOG)
+    assert date == "2026-08-01"
+    assert "feature one" in section
+    assert "a bug" in section
+
+
+def test_stops_at_next_version():
+    _, section = changelog_section("1.2.0", CHANGELOG)
+    assert "older entry" not in section
+    assert "something in flight" not in section
+
+
+def test_last_section_stops_at_link_definitions():
+    _, section = changelog_section("1.1.0", CHANGELOG)
+    assert "older entry" in section
+    assert "example.com" not in section
+
+
+def test_missing_version_exits():
+    with pytest.raises(SystemExit) as e:
+        changelog_section("9.9.9", CHANGELOG)
+    assert "9.9.9" in str(e.value)

--- a/scripts/tests/test_draft_release.py
+++ b/scripts/tests/test_draft_release.py
@@ -1,6 +1,6 @@
 import pytest
 
-from draft_release import changelog_section
+from draft_release import changelog_section, version_from
 
 CHANGELOG = """# Changelog
 
@@ -55,3 +55,10 @@ def test_missing_version_exits():
     with pytest.raises(SystemExit) as e:
         changelog_section("9.9.9", CHANGELOG)
     assert "9.9.9" in str(e.value)
+
+
+def test_version_from_tag_formats():
+    assert version_from("v0.14.0") == "0.14.0"
+    assert version_from("0.14.0") == "0.14.0"
+    assert version_from("agent-walker/0.14.0") == "0.14.0"
+    assert version_from("agent-walker/v0.14.0") == "0.14.0"

--- a/scripts/tests/test_draft_release.py
+++ b/scripts/tests/test_draft_release.py
@@ -1,6 +1,6 @@
 import pytest
 
-from draft_release import changelog_section, version_from
+from draft_release import changelog_section, usage, version_from
 
 CHANGELOG = """# Changelog
 
@@ -62,3 +62,16 @@ def test_version_from_tag_formats():
     assert version_from("0.14.0") == "0.14.0"
     assert version_from("agent-walker/0.14.0") == "0.14.0"
     assert version_from("agent-walker/v0.14.0") == "0.14.0"
+
+
+def test_version_from_rejects_foreign_package():
+    with pytest.raises(SystemExit) as e:
+        version_from("other/0.13.1")
+    assert "other/0.13.1" in str(e.value)
+
+
+def test_usage_stable_vs_prerelease():
+    assert "npx agent-walker" in usage("0.14.0")
+    assert "npx" not in usage("0.14.0-rc.1")
+    assert "prerelease" in usage("0.14.0-rc.1")
+    assert "npx agent-walker" in usage("0.14.0+build5")

--- a/scripts/tests/test_tweet_release.py
+++ b/scripts/tests/test_tweet_release.py
@@ -1,0 +1,64 @@
+from tweet_release import MAX_WEIGHT, bullets_from, compose, effective_weight, weight
+
+BODY = """## Release Notes
+
+### Added
+
+- `SKILLS` (Claude tab): **token volume** per skill, read from the
+  [attribution field](https://example.com/docs) recent versions write (#30). More prose
+  in a second sentence.
+- Short one.
+
+## Install agent-walker 1.2.0
+
+- this bullet must not appear
+"""
+
+
+def test_weight_counts_cjk_as_two():
+    assert weight("abc") == 3
+    assert weight("あ") == 2
+
+
+def test_bullets_strip_markup_and_scope():
+    bullets = bullets_from(BODY)
+    assert len(bullets) == 2
+    first = bullets[0]
+    assert "**" not in first and "`" not in first
+    assert "https://" not in first
+    assert "(#30)" not in first
+    assert "second sentence" not in first  # first clause only
+    assert "must not appear" not in " ".join(bullets)
+
+
+def test_bullets_cap_length():
+    long_bullet = "- " + "word " * 40
+    bullets = bullets_from("## Release Notes\n\n" + long_bullet)
+    assert len(bullets[0]) <= 90
+    assert bullets[0].endswith("…")
+
+
+def test_effective_weight_counts_urls_as_23():
+    assert effective_weight("https://example.com/a/very/long/path") == 23
+    assert effective_weight("ab https://example.com/x") == 3 + 23
+
+
+def test_compose_fits_and_contains_anchor():
+    tweet = compose("v1.2.0", BODY)
+    assert "agent-walker v1.2.0" in tweet
+    assert "releases/tag/v1.2.0" in tweet
+    assert effective_weight(tweet) <= MAX_WEIGHT
+
+
+def test_compose_many_bullets_still_fits():
+    body = "## Release Notes\n\n" + "\n".join(
+        f"- feature number {i} with some words" for i in range(20)
+    )
+    tweet = compose("v1.2.0", body)
+    assert effective_weight(tweet) <= MAX_WEIGHT
+
+
+def test_compose_without_bullets():
+    tweet = compose("v1.2.0", "## Release Notes\n\nno bullets here")
+    assert effective_weight(tweet) <= MAX_WEIGHT
+    assert "releases/tag/v1.2.0" in tweet

--- a/scripts/tests/test_tweet_release.py
+++ b/scripts/tests/test_tweet_release.py
@@ -62,3 +62,9 @@ def test_compose_without_bullets():
     tweet = compose("v1.2.0", "## Release Notes\n\nno bullets here")
     assert effective_weight(tweet) <= MAX_WEIGHT
     assert "releases/tag/v1.2.0" in tweet
+
+
+def test_compose_package_qualified_tag():
+    tweet = compose("agent-walker/1.2.0", BODY)
+    assert tweet.startswith("agent-walker 1.2.0\n")
+    assert "releases/tag/agent-walker/1.2.0" in tweet

--- a/scripts/tweet_release.py
+++ b/scripts/tweet_release.py
@@ -1,0 +1,102 @@
+import json
+import os
+import re
+import sys
+
+MAX_WEIGHT = 280
+URL_WEIGHT = 23  # every URL counts as 23 chars on X
+
+
+def weight(text: str) -> int:
+    # X counts chars above U+10FF as 2
+    return sum(2 if ord(c) > 0x10FF else 1 for c in text)
+
+
+def bullets_from(body: str) -> list[str]:
+    body = re.sub(r"^## Release Notes\s*", "", body.strip())
+    body = re.split(r"^## ", body, maxsplit=1, flags=re.MULTILINE)[0]
+    out = []
+    for m in re.finditer(r"^- (.+?)(?=^[^\s]|\Z)", body, re.MULTILINE | re.DOTALL):
+        text = " ".join(m.group(1).split())
+        text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+        text = re.sub(r"https?://\S+", "", text)
+        text = text.replace("`", "").replace("**", "")
+        text = re.sub(r"\s*\(#\d+\)", "", text)
+        text = " ".join(text.split())
+        text = re.split(r"(?<=[.!?]) ", text)[0].rstrip(".")
+        if len(text) > 90:
+            text = text[:89].rstrip() + "…"
+        out.append(text)
+    return out
+
+
+def effective_weight(tweet: str) -> int:
+    stripped, n = re.subn(r"https?://\S+", "", tweet)
+    return weight(stripped) + n * URL_WEIGHT
+
+
+def compose(tag: str, body: str) -> str:
+    head = f"agent-walker {tag}"
+    url = f"https://github.com/miiiiiiich/agent-walker/releases/tag/{tag}"
+    budget = MAX_WEIGHT - weight(head) - 2 - (URL_WEIGHT + 2)
+    lines = []
+    for b in bullets_from(body):
+        line = f"・{b}"
+        w = weight(line) + 1
+        if w > budget:
+            if not lines and budget > 40:
+                while weight(line) + 1 > budget:
+                    line = line[:-8] + "…"
+                lines.append(line)
+            break
+        lines.append(line)
+        budget -= w
+
+    def build(ls: list[str]) -> str:
+        parts = [head] + ([""] + ls if ls else []) + ["", url]
+        return "\n".join(parts)
+
+    tweet = build(lines)
+    while lines and effective_weight(tweet) > MAX_WEIGHT:
+        lines.pop()
+        tweet = build(lines)
+    if effective_weight(tweet) > MAX_WEIGHT:
+        sys.exit(f"tweet still overweight ({effective_weight(tweet)}) with no bullets left")
+    return tweet
+
+
+def main() -> None:
+    with open("release.json") as f:
+        release = json.load(f)
+    tweet = compose(release["tag_name"], release.get("body") or "")
+    print(tweet)
+    print(f"--- effective weight: {effective_weight(tweet)}/280", file=sys.stderr)
+
+    if os.environ.get("DRY_RUN", "").lower() == "true":
+        print("dry run — not posting", file=sys.stderr)
+        return
+
+    keys = ["X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_TOKEN_SECRET"]
+    missing = [k for k in keys if not os.environ.get(k)]
+    if missing:
+        sys.exit(f"missing secrets: {', '.join(missing)}")
+
+    from requests_oauthlib import OAuth1Session
+
+    session = OAuth1Session(
+        os.environ["X_API_KEY"],
+        client_secret=os.environ["X_API_SECRET"],
+        resource_owner_key=os.environ["X_ACCESS_TOKEN"],
+        resource_owner_secret=os.environ["X_ACCESS_TOKEN_SECRET"],
+    )
+    try:
+        resp = session.post("https://api.x.com/2/tweets", json={"text": tweet}, timeout=30)
+    except Exception as e:  # noqa: BLE001 — any network failure must fail the job, not hang it
+        sys.exit(f"post failed: {e}")
+    if resp.status_code != 201:
+        sys.exit(f"post failed: {resp.status_code} {resp.text}")
+    print(f"posted: {resp.json()['data']['id']}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tweet_release.py
+++ b/scripts/tweet_release.py
@@ -36,7 +36,8 @@ def effective_weight(tweet: str) -> int:
 
 
 def compose(tag: str, body: str) -> str:
-    head = f"agent-walker {tag}"
+    # package-qualified tags (agent-walker/0.14.0) would double the name
+    head = f"agent-walker {tag.rsplit('/', 1)[-1]}"
     url = f"https://github.com/miiiiiiich/agent-walker/releases/tag/{tag}"
     budget = MAX_WEIGHT - weight(head) - 2 - (URL_WEIGHT + 2)
     lines = []

--- a/scripts/uv.lock
+++ b/scripts/uv.lock
@@ -1,0 +1,270 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "release-scripts"
+version = "0.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "requests-oauthlib" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "requests-oauthlib", specifier = ">=2.0.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pyright", specifier = ">=1.1.390" },
+    { name = "pytest", specifier = ">=8" },
+    { name = "ruff", specifier = ">=0.8" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/e1/4508a569211b35599016e84ba65c1a992b7a4004b4b6c4bea02a851cba1b/ruff-0.16.2.tar.gz", hash = "sha256:c3d7828d12e8927a6fc65fe38e2c2541b9e762d360a1786d752cb1b8883b3c9c", size = 4885811, upload-time = "2026-08-07T13:31:01.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/57/db19951540f98859c956b50bdb4d31089b4d91e9f15e2968e7d5193806d5/ruff-0.16.2-py3-none-linux_armv6l.whl", hash = "sha256:3c8de4cf2181f01d57946d87d777aa52916976fc09942aed89938fab5e013318", size = 10847925, upload-time = "2026-08-07T13:30:14.468Z" },
+    { url = "https://files.pythonhosted.org/packages/13/5a/995fe85a8470d3e391ac0f7fa8054bb454eaf33ee138196d6172ed1079c0/ruff-0.16.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9a48cc05c6fbc811ca81b5d7ba95375affea6582d1b8024e455e41afbbf55344", size = 11072662, upload-time = "2026-08-07T13:30:18.143Z" },
+    { url = "https://files.pythonhosted.org/packages/32/53/370d767c61c71a971a4ace36703a7ecd8c393956349a7325d7fab2b56827/ruff-0.16.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a2c0d14fcbb26c91f0f867a6dc9bd71bbc30b1b6151829c884f23faeab2e5700", size = 10566771, upload-time = "2026-08-07T13:30:20.899Z" },
+    { url = "https://files.pythonhosted.org/packages/85/d6/9d96948caf5a632be62d62202d5ec914d6856f204fd79eb036e5915e79ea/ruff-0.16.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:335c621622c4650330be50842561c6586ac6971bb8ab5407fe34dcc9efb16bbe", size = 10975825, upload-time = "2026-08-07T13:30:23.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/ea87129b3414acb0b5770563779c51804d37ac67675c7ba35447ddb14773/ruff-0.16.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:20e66910f2c37cc753f9ef6580c914a621b80c4fa3549d3e3521e29d0f5bfc3f", size = 10649437, upload-time = "2026-08-07T13:30:26.097Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/43/f8f291dcd4af5bb7872b74fdfa41a7cd7c856ca1d4069670971cf1b9f5cb/ruff-0.16.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7e36fbfba65510548156902bcf1350a979a958ce0347ce0f90d73894036b39f", size = 11446761, upload-time = "2026-08-07T13:30:28.752Z" },
+    { url = "https://files.pythonhosted.org/packages/71/4a/ef991fb2fcf516ab71f0808adcdd8da5e18c8cde447f4ceaf5f47a5132a5/ruff-0.16.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0eab35f80df8f134aae5d1630e751901321d317cc8e50dc39e36fa3ed34cd12", size = 12336364, upload-time = "2026-08-07T13:30:31.468Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/24/f615e74f307e6ca0e56a482872477b856c70d530aa356abfb6dfe5ca8a80/ruff-0.16.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40ea8c0594feb894e89c8c61ab9c103d38b0ea72dfde6c594107147ca31b1140", size = 11630720, upload-time = "2026-08-07T13:30:34.426Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d3/8ef50149e8412a77f7ab409efdef0e2b23803707a3863da4fc64cb23d459/ruff-0.16.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ab3d62dde0b19facdd632008cc4827fc28ada7736c6bd35ab6f1050f0bfed53f", size = 11466130, upload-time = "2026-08-07T13:30:36.958Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a7/a19334985c4dea8c381981fa252cd854c7ee52dc4b1686dc16f4a911c702/ruff-0.16.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:e43e1f5b8388da9eca1b9e88328d47a5cec794633ccf6f7484ac2dd15eee92c0", size = 11523634, upload-time = "2026-08-07T13:30:39.822Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6c/96d192b0e742412ceda08c0a50f9669b253dde9fd6a60ea1a10c9fa79a63/ruff-0.16.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:c24788a980581e1d7ea3a0cbe4344c4fbeb0a6a9b1f4713aa46bb104f8294690", size = 10949807, upload-time = "2026-08-07T13:30:42.745Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/51/e26599ceca11e79ee255c7df515995561edf87e9ca1893284e44d98f5a86/ruff-0.16.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:81806b08329130005dd4a8a8394a0c9da8c6f4cafb16ba438d2a2ee6a18bedf1", size = 10646891, upload-time = "2026-08-07T13:30:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/68/01/800c4b1f97bc8d7c6029e06b1f20473a3cf1e13c4933d8f3342add83fc55/ruff-0.16.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:4ce4e02bad779bef557f541a1b31f20d6abeae1cc05ed1b1ac019d4ffd1044c8", size = 11162063, upload-time = "2026-08-07T13:30:48.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d0/1477ea50fc5a0d4b0b71d1d63d50770bdd794d90b43e37a7618e63ec9894/ruff-0.16.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e0422abdf70070255fc4073ce9dfc814cc03db577013761ddd09bc1e4a9a4fbd", size = 11556038, upload-time = "2026-08-07T13:30:50.686Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/76/a7776f32048d991e16d4fa8ff91790b877342d3596cc3ed04acdbf1aaedc/ruff-0.16.2-py3-none-win32.whl", hash = "sha256:bf3a63d78fb39f4bf5ac8ae52051c5520505301abe19ba4e204c453b3f09bb0b", size = 10872850, upload-time = "2026-08-07T13:30:53.471Z" },
+    { url = "https://files.pythonhosted.org/packages/00/0d/929c800d920e61397d82a01b60bffc68da3052c17d31de59efaad2e4ed75/ruff-0.16.2-py3-none-win_amd64.whl", hash = "sha256:bcabe2f6d0fc7819f1431793005af4e4de7371927d037345bf941252b195b9fa", size = 12023338, upload-time = "2026-08-07T13:30:56.193Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/93e26c22c5f78ff87363e07da49c84955affbeb1098bd1936bf3b3f293bf/ruff-0.16.2-py3-none-win_arm64.whl", hash = "sha256:d614e95cedf38a2053fd351c55b103ba30d017d61688fdbfd40ee0412852a99f", size = 11374065, upload-time = "2026-08-07T13:30:58.775Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]


### PR DESCRIPTION
## Why

The release body was cargo-dist boilerplate — the npm hint misleads CLI users, and dist has no option to edit the text.

## Changes

- **Own the release body**: `create-release = false` + a custom plan-job drafts the release from the CHANGELOG section. No section → the release stops before building.
- **Tweet on release**: fires on Release workflow completion, same-repo tag pushes only. Needs four `X_*` secrets; failure never blocks the release.
- **Drop Intel macOS builds**: 8 of ~9.5 wall-clock minutes, for hardware Apple no longer ships.
- **Python → `scripts/`** as a uv project (pytest / ruff / pyright green).

## Test

Dry-runs against real v0.13.1/v0.9.0 data, `dist plan` verified locally, 3 codex review rounds. First live run is the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)