### PR TITLE
Tweet whole sentences; version-only release titles

### DIFF
--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -7,17 +7,19 @@ CHANGELOG = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
 CARGO_TOML = Path(__file__).resolve().parents[1] / "Cargo.toml"
 
 
-def changelog_section(version: str, changelog: str) -> tuple[str, str]:
+def changelog_section(version: str, changelog: str) -> str:
+    # the Keep-a-Changelog heading format (## [x.y.z] - date) is still
+    # required; the date itself is unused — GitHub renders release dates.
     # a section ends at the next version heading or at the footer's
     # link-reference definitions — not at any body line starting with "["
     pattern = re.compile(
-        r"^## \[" + re.escape(version) + r"\] - (\S+)\s*\n(.*?)(?=^## \[|^\[[^\]]+\]:|\Z)",
+        r"^## \[" + re.escape(version) + r"\] - \S+\s*\n(.*?)(?=^## \[|^\[[^\]]+\]:|\Z)",
         re.MULTILINE | re.DOTALL,
     )
     m = pattern.search(changelog)
     if not m:
         sys.exit(f"CHANGELOG.md has no section for [{version}] — write it before tagging")
-    return m.group(1), m.group(2).strip()
+    return m.group(1).strip()
 
 
 def version_from(tag: str) -> str:
@@ -61,7 +63,7 @@ def main() -> None:
     tag = sys.argv[1]
     version = version_from(tag)
     check_version_matches(version, CARGO_TOML.read_text())
-    _date, section = changelog_section(version, CHANGELOG.read_text())
+    section = changelog_section(version, CHANGELOG.read_text())
 
     if "--title" in sys.argv[2:]:
         # version only — GitHub renders the release date itself

--- a/scripts/draft_release.py
+++ b/scripts/draft_release.py
@@ -61,10 +61,11 @@ def main() -> None:
     tag = sys.argv[1]
     version = version_from(tag)
     check_version_matches(version, CARGO_TOML.read_text())
-    date, section = changelog_section(version, CHANGELOG.read_text())
+    _date, section = changelog_section(version, CHANGELOG.read_text())
 
     if "--title" in sys.argv[2:]:
-        print(f"{version} - {date}")
+        # version only — GitHub renders the release date itself
+        print(f"v{version}")
         return
 
     body = f"""## Release Notes

--- a/scripts/tests/test_draft_release.py
+++ b/scripts/tests/test_draft_release.py
@@ -42,21 +42,20 @@ CHANGELOG = """# Changelog
 """
 
 
-def test_extracts_date_and_section():
-    date, section = changelog_section("1.2.0", CHANGELOG)
-    assert date == "2026-08-01"
+def test_extracts_section():
+    section = changelog_section("1.2.0", CHANGELOG)
     assert "feature one" in section
     assert "a bug" in section
 
 
 def test_stops_at_next_version():
-    _, section = changelog_section("1.2.0", CHANGELOG)
+    section = changelog_section("1.2.0", CHANGELOG)
     assert "older entry" not in section
     assert "something in flight" not in section
 
 
 def test_last_section_stops_at_link_definitions():
-    _, section = changelog_section("1.1.0", CHANGELOG)
+    section = changelog_section("1.1.0", CHANGELOG)
     assert "older entry" in section
     assert "example.com" not in section
 
@@ -81,7 +80,7 @@ def test_version_from_arbitrary_prefixes():
 
 
 def test_inline_links_do_not_truncate_section():
-    _, section = changelog_section("1.2.0", CHANGELOG)
+    section = changelog_section("1.2.0", CHANGELOG)
     assert "Migration guide" in section
     assert "a bug" in section
 

--- a/scripts/tests/test_tweet_release.py
+++ b/scripts/tests/test_tweet_release.py
@@ -24,6 +24,7 @@ def test_bullets_strip_markup_and_scope():
     bullets = bullets_from(BODY)
     assert len(bullets) == 2
     first = bullets[0]
+    assert first.startswith("Added: ")
     assert "**" not in first and "`" not in first
     assert "https://" not in first
     assert "(#30)" not in first
@@ -31,11 +32,12 @@ def test_bullets_strip_markup_and_scope():
     assert "must not appear" not in " ".join(bullets)
 
 
-def test_bullets_cap_length():
-    long_bullet = "- " + "word " * 40
-    bullets = bullets_from("## Release Notes\n\n" + long_bullet)
-    assert len(bullets[0]) <= 90
-    assert bullets[0].endswith("…")
+def test_compose_skips_oversized_bullets_without_truncation():
+    body = "## Release Notes\n\n### Added\n\n- " + "word " * 60 + "\n- Short and sweet.\n"
+    tweet = compose("v1.2.0", body)
+    assert "…" not in tweet
+    assert "・Added: Short and sweet" in tweet
+    assert "word word word" not in tweet
 
 
 def test_effective_weight_counts_urls_as_23():

--- a/scripts/tweet_release.py
+++ b/scripts/tweet_release.py
@@ -16,17 +16,18 @@ def bullets_from(body: str) -> list[str]:
     body = re.sub(r"^## Release Notes\s*", "", body.strip())
     body = re.split(r"^## ", body, maxsplit=1, flags=re.MULTILINE)[0]
     out = []
-    for m in re.finditer(r"^- (.+?)(?=^[^\s]|\Z)", body, re.MULTILINE | re.DOTALL):
-        text = " ".join(m.group(1).split())
-        text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
-        text = re.sub(r"https?://\S+", "", text)
-        text = text.replace("`", "").replace("**", "")
-        text = re.sub(r"\s*\(#\d+\)", "", text)
-        text = " ".join(text.split())
-        text = re.split(r"(?<=[.!?]) ", text)[0].rstrip(".")
-        if len(text) > 90:
-            text = text[:89].rstrip() + "…"
-        out.append(text)
+    # [preamble, section1, chunk1, section2, chunk2, …]
+    parts = re.split(r"^### +(.+)$", body, flags=re.MULTILINE)
+    for section, chunk in zip(["", *parts[1::2]], [parts[0], *parts[2::2]]):
+        for m in re.finditer(r"^- (.+?)(?=^[^\s]|\Z)", chunk, re.MULTILINE | re.DOTALL):
+            text = " ".join(m.group(1).split())
+            text = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", text)
+            text = re.sub(r"https?://\S+", "", text)
+            text = text.replace("`", "").replace("**", "")
+            text = re.sub(r"\s*\(#\d+\)", "", text)
+            text = " ".join(text.split())
+            text = re.split(r"(?<=[.!?]) ", text)[0].rstrip(".")
+            out.append(f"{section.strip()}: {text}" if section.strip() else text)
     return out
 
 
@@ -45,11 +46,9 @@ def compose(tag: str, body: str) -> str:
         line = f"・{b}"
         w = weight(line) + 1
         if w > budget:
-            if not lines and budget > 40:
-                while weight(line) + 1 > budget:
-                    line = line[:-8] + "…"
-                lines.append(line)
-            break
+            # whole sentences only — a bullet that doesn't fit is skipped,
+            # never cut mid-text; the release link carries the rest
+            continue
         lines.append(line)
         budget -= w
 


### PR DESCRIPTION
## Summary

The v0.13.2 announcement showed mid-sentence ellipsis cuts. Bullets now carry their changelog section (`Added:` / `Removed:`) and are included only when the whole first sentence fits — nothing is ever cut mid-text; the release link carries the rest. Release titles drop the date (`v0.13.2` instead of `0.13.2 - 2026-08-14`): GitHub renders the date itself, and a survey of 8 major repos (uv, ruff, tokio, ripgrep, clap, …) found none that include it.

## Test Plan

- 17 script tests green (new: oversized bullets are skipped, never truncated); ruff / pyright clean
- Dry-run against the published v0.13.2 release body renders both bullets whole at 235/280

🤖 Generated with [Claude Code](https://claude.com/claude-code)