### PR TITLE
Granted-autonomy mix in MODES

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -379,6 +379,7 @@ mod tests {
             credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
+            permission_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -436,6 +437,7 @@ mod tests {
             credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
+            permission_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -483,6 +485,7 @@ mod tests {
             credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
+            permission_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -514,8 +517,8 @@ mod v09_tests {
     use super::*;
     use crate::model::LimitDay;
     use crate::model::{
-        Collection, EffortEvent, ModeEvent, Provider, RateLimitSample, ScanStats, SourceKind,
-        UsageEvent,
+        Collection, EffortEvent, ModeEvent, PermissionEvent, Provider, RateLimitSample, ScanStats,
+        SourceKind, UsageEvent,
     };
 
     fn skill_event(at: OffsetDateTime, skill: Option<&str>, tokens: u64) -> UsageEvent {
@@ -538,6 +541,7 @@ mod v09_tests {
     /// SKILLS / LIMITS / MODES all cut on the fixed 30-day codename window
     /// (display `--days` = 90 here), and LIMITS days are tri-state.
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn v09_sections_use_fixed_window_and_tristate_days() {
         let now = datetime!(2026-06-30 12:00 UTC);
         let collection = Collection {
@@ -612,6 +616,25 @@ mod v09_tests {
                     fast: true,
                 },
             ],
+            permission_events: vec![
+                PermissionEvent {
+                    timestamp: Some(datetime!(2026-06-25 10:00 UTC)),
+                    mode: "dontAsk".to_owned(),
+                },
+                PermissionEvent {
+                    timestamp: Some(datetime!(2026-06-25 11:00 UTC)),
+                    mode: "dontAsk".to_owned(),
+                },
+                PermissionEvent {
+                    timestamp: Some(datetime!(2026-06-25 12:00 UTC)),
+                    mode: "auto".to_owned(),
+                },
+                // Outside the 30d window: ignored.
+                PermissionEvent {
+                    timestamp: Some(datetime!(2026-05-20 10:00 UTC)),
+                    mode: "default".to_owned(),
+                },
+            ],
             stats: ScanStats::default(),
         };
 
@@ -642,6 +665,10 @@ mod v09_tests {
         assert_eq!(summary.modes.assistant_turns, 2);
         assert_eq!(summary.modes.thinking_turns, 1);
         assert_eq!(summary.modes.fast_turns, 0);
+        assert_eq!(
+            summary.modes.permissions,
+            vec![("dontAsk".to_owned(), 2), ("auto".to_owned(), 1)]
+        );
         assert_eq!(
             summary.modes.efforts,
             vec![("xhigh".to_owned(), 2), ("low".to_owned(), 1)]

--- a/src/analyzer/concurrency.rs
+++ b/src/analyzer/concurrency.rs
@@ -136,6 +136,7 @@ mod tests {
             credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
+            permission_events: Vec::new(),
             stats: ScanStats::default(),
         }
     }

--- a/src/analyzer/modes.rs
+++ b/src/analyzer/modes.rs
@@ -1,5 +1,5 @@
-//! MODES panel data: Claude thinking / fast flags and the reasoning-effort
-//! mix (Claude and Codex).
+//! MODES panel data: Claude thinking / fast flags, the reasoning-effort mix,
+//! and the granted-autonomy (permission) mix (Claude and Codex).
 use std::collections::BTreeMap;
 
 use time::{Date, OffsetDateTime, UtcOffset};
@@ -44,6 +44,18 @@ pub(super) fn modes_summary(
     modes.efforts = effort_counts.into_iter().collect();
     modes
         .efforts
+        .sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+
+    let mut permission_counts: BTreeMap<String, usize> = BTreeMap::new();
+    for event in &collection.permission_events {
+        if !in_window(event.timestamp) {
+            continue;
+        }
+        *permission_counts.entry(event.mode.clone()).or_default() += 1;
+    }
+    modes.permissions = permission_counts.into_iter().collect();
+    modes
+        .permissions
         .sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
     modes
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -22,7 +22,7 @@ mod walk;
 pub use cache::parse_files_cached;
 pub use events::{
     FileEvents, KeyedCreditSample, KeyedDurationEvent, KeyedEffortEvent, KeyedModeEvent,
-    KeyedRateLimitSample, KeyedToolEvent, KeyedUsageEvent,
+    KeyedPermissionEvent, KeyedRateLimitSample, KeyedToolEvent, KeyedUsageEvent,
 };
 pub use merge::merge_into;
 pub use project::project_from_cwd;

--- a/src/collector/cache.rs
+++ b/src/collector/cache.rs
@@ -33,9 +33,11 @@ use super::events::FileEvents;
 ///   dedup), changing the `FileEvents` layout.
 /// - 14: Claude top-level `effort` extraction — v13 caches deserialize fine
 ///   but carry empty effort events for already-parsed sessions.
+/// - 15: `FileEvents` gained `permission_events` (autonomy mix), changing
+///   its bincode layout.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
-const CACHE_VERSION: u32 = 14;
+const CACHE_VERSION: u32 = 15;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct FileStamp {

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -8,12 +8,12 @@ use time::format_description::well_known::Rfc3339;
 use time::{Duration, OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedModeEvent, KeyedToolEvent,
-    KeyedUsageEvent, list_files, merge_into, parse_files_cached, project_from_cwd,
+    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedModeEvent, KeyedPermissionEvent,
+    KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached, project_from_cwd,
 };
 use crate::model::{
-    Collection, DurationEvent, EffortEvent, ModeEvent, Provider, SessionTouch, SourceKind,
-    TokenUsage, ToolEvent, UsageEvent,
+    Collection, DurationEvent, EffortEvent, ModeEvent, PermissionEvent, Provider, SessionTouch,
+    SourceKind, TokenUsage, ToolEvent, UsageEvent,
 };
 
 /// Background/observer harnesses (e.g. the claude-mem observer) keep
@@ -267,6 +267,7 @@ fn parse_line(
 
     collect_mode_event(value, message, timestamp, events);
     collect_effort_event(value, message, timestamp, events);
+    collect_permission_event(value, timestamp, events);
 
     let usage_value = message.get("usage").or_else(|| value.get("usage"));
     let message_id = string_field(message, "id");
@@ -375,6 +376,32 @@ fn collect_mode_event(
             has_thinking,
             fast,
         },
+    });
+}
+
+/// One permission event per human turn (keyed by the row uuid, which resume /
+/// fork copies share), from the top-level `permissionMode` field. Gated on
+/// `is_human_turn`: cross-session agent-message rows (`isMeta`) also carry
+/// the field and would let orchestration-heavy windows swamp the mix. The
+/// `type:"permission-mode"` change-stream rows are deliberately not used —
+/// per-turn values give the distribution, not just the switch points.
+fn collect_permission_event(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    events: &mut FileEvents,
+) {
+    if !is_human_turn(value) {
+        return;
+    }
+    let Some(mode) = string_field(value, "permissionMode") else {
+        return;
+    };
+    let Some(uuid) = string_field(value, "uuid") else {
+        return;
+    };
+    events.permission_events.push(KeyedPermissionEvent {
+        key: Some(format!("claude-permission:{uuid}")),
+        event: PermissionEvent { timestamp, mode },
     });
 }
 
@@ -666,6 +693,40 @@ mod tests {
         assert!(collection.mode_events[0].fast);
         assert!(!collection.mode_events[1].has_thinking);
         assert!(!collection.mode_events[1].fast);
+    }
+
+    /// The top-level `permissionMode` field on user rows becomes one
+    /// permission event per turn; resume/fork copies share the row uuid and
+    /// dedupe, and rows without the field contribute nothing.
+    #[test]
+    fn collects_permission_events_deduped_by_uuid() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-07-20T00:00:00Z","sessionId":"s1","type":"user","uuid":"u1","permissionMode":"dontAsk","message":{"role":"user","content":"do it"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:00:00Z","sessionId":"s1","type":"user","uuid":"u1","permissionMode":"dontAsk","message":{"role":"user","content":"do it"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:01:00Z","sessionId":"s1","type":"user","uuid":"u2","permissionMode":"auto","message":{"role":"user","content":"next"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:02:00Z","sessionId":"s1","type":"user","uuid":"u3","message":{"role":"user","content":"no mode field"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:03:00Z","sessionId":"s1","type":"user","uuid":"u4","isMeta":true,"permissionMode":"bypassPermissions","message":{"role":"user","content":"agent-message injection"}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        let mut modes: Vec<&str> = collection
+            .permission_events
+            .iter()
+            .map(|event| event.mode.as_str())
+            .collect();
+        modes.sort_unstable();
+        assert_eq!(modes, ["auto", "dontAsk"]);
     }
 
     /// The top-level `effort` field (present since CLI v2.1.212) becomes one

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -9,12 +9,12 @@ use time::format_description::well_known::Rfc3339;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedRateLimitSample, KeyedToolEvent,
-    KeyedUsageEvent, list_files, merge_into, parse_files_cached, project_from_cwd,
+    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedPermissionEvent, KeyedRateLimitSample,
+    KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached, project_from_cwd,
 };
 use crate::model::{
-    Collection, DurationEvent, EffortEvent, Provider, RateLimitSample, SessionTouch, SourceKind,
-    TokenUsage, ToolEvent, UsageEvent,
+    Collection, DurationEvent, EffortEvent, PermissionEvent, Provider, RateLimitSample,
+    SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
 };
 
 pub fn collect(
@@ -127,6 +127,13 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
             current_model = string_path(&value, &["payload", "model"]).or(current_model);
             if !in_replay_burst {
                 collect_effort_event(
+                    &value,
+                    timestamp,
+                    current_session_id.as_ref(),
+                    line_index,
+                    &mut events,
+                );
+                collect_permission_event(
                     &value,
                     timestamp,
                     current_session_id.as_ref(),
@@ -314,6 +321,27 @@ fn collect_effort_event(
     events.effort_events.push(KeyedEffortEvent {
         key,
         event: EffortEvent { timestamp, effort },
+    });
+}
+
+fn collect_permission_event(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    line_index: usize,
+    events: &mut FileEvents,
+) {
+    let Some(mode) = string_path(value, &["payload", "approval_policy"]) else {
+        return;
+    };
+    let key = match (session_id, string_path(value, &["payload", "turn_id"])) {
+        (Some(sid), Some(turn_id)) => Some(format!("codex-permission:v2:{sid}:{turn_id}")),
+        (Some(sid), None) => positional_key("codex-permission", sid, timestamp, line_index),
+        _ => None,
+    };
+    events.permission_events.push(KeyedPermissionEvent {
+        key,
+        event: PermissionEvent { timestamp, mode },
     });
 }
 
@@ -694,7 +722,7 @@ mod tests {
             concat!(
                 r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"xhigh"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"xhigh","approval_policy":"never"}}"#,
                 "\n",
                 r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":10,"total_tokens":110}},"rate_limits":{"primary":{"used_percent":37.5,"window_minutes":300},"secondary":{"used_percent":12.0,"window_minutes":10080}}}}"#,
                 "\n",
@@ -709,6 +737,8 @@ mod tests {
 
         assert_eq!(collection.effort_events.len(), 1);
         assert_eq!(collection.effort_events[0].effort, "xhigh");
+        assert_eq!(collection.permission_events.len(), 1);
+        assert_eq!(collection.permission_events[0].mode, "never");
         // Only the PRIMARY (5h) window is sampled; the weekly window is
         // deliberately dropped from the LIMITS history.
         assert_eq!(collection.rate_limit_samples.len(), 1);
@@ -757,7 +787,7 @@ mod tests {
         concat!(
             r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"p1","model_provider":"openai"}}"#,
             "\n",
-            r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t1"}}"#,
+            r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","approval_policy":"on-request","turn_id":"t1"}}"#,
             "\n",
             r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":110},"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":110}},"rate_limits":{"primary":{"used_percent":10.0,"window_minutes":300,"resets_at":1750000000}}}}"#,
             "\n",
@@ -778,7 +808,7 @@ mod tests {
             "\n",
             r#"{"timestamp":"2026-06-01T01:00:00Z","type":"session_meta","payload":{"id":"p1","model_provider":"openai"}}"#,
             "\n",
-            r#"{"timestamp":"2026-06-01T01:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t1"}}"#,
+            r#"{"timestamp":"2026-06-01T01:00:00Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","approval_policy":"on-request","turn_id":"t1"}}"#,
             "\n",
             r#"{"timestamp":"2026-06-01T01:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":110},"total_token_usage":{"input_tokens":100,"cached_input_tokens":40,"output_tokens":10,"total_tokens":110}},"rate_limits":{"primary":{"used_percent":10.0,"window_minutes":300,"resets_at":1750000000}}}}"#,
             "\n",
@@ -786,7 +816,7 @@ mod tests {
             "\n",
             r#"{"timestamp":"2026-06-01T01:00:00Z","type":"event_msg","payload":{"type":"task_complete","duration_ms":111}}"#,
             "\n",
-            r#"{"timestamp":"2026-06-01T01:00:05Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"xhigh","turn_id":"t9"}}"#,
+            r#"{"timestamp":"2026-06-01T01:00:05Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"xhigh","approval_policy":"never","turn_id":"t9"}}"#,
             "\n",
             r#"{"timestamp":"2026-06-01T01:00:07Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":90,"cached_input_tokens":10,"output_tokens":40,"total_tokens":130},"total_token_usage":{"input_tokens":310,"cached_input_tokens":50,"output_tokens":70,"total_tokens":380}},"rate_limits":{"primary":{"used_percent":15.0,"window_minutes":300,"resets_at":1750018000}}}}"#,
             "\n",
@@ -893,6 +923,8 @@ mod tests {
         assert_eq!(collection.rate_limit_samples.len(), 1);
         assert_eq!(collection.effort_events.len(), 1);
         assert_eq!(collection.effort_events[0].effort, "xhigh");
+        assert_eq!(collection.permission_events.len(), 1);
+        assert_eq!(collection.permission_events[0].mode, "never");
         assert_eq!(collection.duration_events.len(), 1);
         assert_eq!(collection.duration_events[0].duration_ms, 222);
     }
@@ -967,11 +999,11 @@ mod tests {
             concat!(
                 r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1","model_provider":"openai"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t1"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","approval_policy":"on-request","turn_id":"t1"}}"#,
                 "\n",
                 r#"{"timestamp":"2026-06-01T00:00:02Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t2"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-06-01T00:00:59Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t1"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:59Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","approval_policy":"on-request","turn_id":"t1"}}"#,
                 "\n"
             ),
         )
@@ -1050,7 +1082,7 @@ mod tests {
             concat!(
                 r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1","model_provider":"openai"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t1"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","approval_policy":"on-request","turn_id":"t1"}}"#,
                 "\n",
                 r#"{"timestamp":"2026-06-01T00:00:03Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"total_tokens":110},"total_token_usage":{"input_tokens":100,"cached_input_tokens":0,"output_tokens":10,"total_tokens":110}}}}"#,
                 "\n",
@@ -1081,7 +1113,7 @@ mod tests {
             concat!(
                 r#"{"timestamp":"2026-06-01T00:00:00Z","type":"session_meta","payload":{"id":"s1","model_provider":"openai"}}"#,
                 "\n",
-                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t1"}}"#,
+                r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","approval_policy":"on-request","turn_id":"t1"}}"#,
                 "\n",
                 r#"{"timestamp":"2026-06-01T00:00:01Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"high","turn_id":"t2"}}"#,
                 "\n"

--- a/src/collector/events.rs
+++ b/src/collector/events.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use time::{Date, OffsetDateTime, UtcOffset};
 
 use crate::model::{
-    CreditSample, DurationEvent, EffortEvent, ModeEvent, RateLimitSample, SessionTouch, ToolEvent,
-    UsageEvent,
+    CreditSample, DurationEvent, EffortEvent, ModeEvent, PermissionEvent, RateLimitSample,
+    SessionTouch, ToolEvent, UsageEvent,
 };
 
 /// Events extracted from a single log file. The unit of caching: parsed once,
@@ -21,6 +21,7 @@ pub struct FileEvents {
     pub credit_samples: Vec<KeyedCreditSample>,
     pub effort_events: Vec<KeyedEffortEvent>,
     pub mode_events: Vec<KeyedModeEvent>,
+    pub permission_events: Vec<KeyedPermissionEvent>,
     pub lines_seen: usize,
     pub parse_errors: usize,
 }
@@ -64,6 +65,12 @@ pub struct KeyedDurationEvent {
 pub struct KeyedEffortEvent {
     pub key: Option<String>,
     pub event: EffortEvent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedPermissionEvent {
+    pub key: Option<String>,
+    pub event: PermissionEvent,
 }
 
 /// Mode event keyed by message id. Duplicate lines for the same message can

--- a/src/collector/merge.rs
+++ b/src/collector/merge.rs
@@ -100,6 +100,7 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
     let mut seen_durations: HashMap<String, usize> = HashMap::new();
     let mut seen_efforts: HashMap<String, usize> = HashMap::new();
     let mut seen_modes: HashMap<String, usize> = HashMap::new();
+    let mut seen_permissions: HashMap<String, usize> = HashMap::new();
 
     for (path, events) in per_file {
         collection.stats.files_seen += 1;
@@ -182,6 +183,18 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
             dedupe_into(
                 &mut collection.effort_events,
                 &mut seen_efforts,
+                keyed.key,
+                keyed.event,
+                |existing, incoming| {
+                    existing.timestamp = older_timestamp(existing.timestamp, incoming.timestamp);
+                },
+            );
+        }
+
+        for keyed in events.permission_events {
+            dedupe_into(
+                &mut collection.permission_events,
+                &mut seen_permissions,
                 keyed.key,
                 keyed.event,
                 |existing, incoming| {

--- a/src/model/events.rs
+++ b/src/model/events.rs
@@ -79,6 +79,15 @@ pub struct EffortEvent {
     pub effort: String,
 }
 
+/// One turn's granted-autonomy setting: Claude's `permissionMode` per user
+/// turn (default / auto / acceptEdits / dontAsk / plan / bypassPermissions),
+/// Codex's `approval_policy` per `turn_context` (never / on-request / …).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PermissionEvent {
+    pub timestamp: Option<OffsetDateTime>,
+    pub mode: String,
+}
+
 /// Per-assistant-message mode flags for Claude: whether extended thinking
 /// fired (a `thinking` content block exists — block presence only, text is
 /// never read) and whether fast mode served it (`usage.speed == "fast"`).
@@ -126,6 +135,7 @@ pub struct Collection {
     pub credit_samples: Vec<CreditSample>,
     pub effort_events: Vec<EffortEvent>,
     pub mode_events: Vec<ModeEvent>,
+    pub permission_events: Vec<PermissionEvent>,
     pub stats: ScanStats,
 }
 
@@ -142,6 +152,7 @@ impl Collection {
             credit_samples: Vec::new(),
             effort_events: Vec::new(),
             mode_events: Vec::new(),
+            permission_events: Vec::new(),
             stats: ScanStats::default(),
         }
     }
@@ -173,6 +184,9 @@ impl Collection {
             combined
                 .mode_events
                 .extend(collection.mode_events.iter().cloned());
+            combined
+                .permission_events
+                .extend(collection.permission_events.iter().cloned());
             combined.stats.add_assign(&collection.stats);
         }
         combined.stats.usage_events = combined.usage_events.len();

--- a/src/model/summary.rs
+++ b/src/model/summary.rs
@@ -102,11 +102,14 @@ pub struct ModesSummary {
     pub fast_turns: usize,
     /// (effort label, turns), sorted by turns descending.
     pub efforts: Vec<(String, usize)>,
+    /// (permission-mode label, turns), sorted by turns descending — Claude's
+    /// `permissionMode`, Codex's `approval_policy`.
+    pub permissions: Vec<(String, usize)>,
 }
 
 impl ModesSummary {
     pub fn is_empty(&self) -> bool {
-        self.assistant_turns == 0 && self.efforts.is_empty()
+        self.assistant_turns == 0 && self.efforts.is_empty() && self.permissions.is_empty()
     }
 }
 

--- a/src/ui/page.rs
+++ b/src/ui/page.rs
@@ -301,6 +301,7 @@ mod tests {
             thinking_turns: 49,
             fast_turns: 0,
             efforts: vec![("xhigh".to_owned(), 93), ("low".to_owned(), 6)],
+            permissions: Vec::new(),
         };
         summary.credits = Some(crate::model::CreditsHistory {
             days: (0..30)

--- a/src/ui/sections/modes.rs
+++ b/src/ui/sections/modes.rs
@@ -3,11 +3,13 @@ use crate::model::Summary;
 use crate::ui::{theme, utils};
 use ratatui::prelude::*;
 
-/// MODES: how the model is allowed to think, per provider dial — Claude
-/// shows the thinking fire rate (plus fast mode once it has data) and its
-/// reasoning-effort mix, Codex the reasoning-effort mix alone. Deliberately
-/// small (a couple of rows): the dials are asymmetric across providers, so
-/// each tab renders only its own rows.
+/// MODES: how the model is allowed to think and act, per provider dial —
+/// Claude shows the thinking fire rate (plus fast mode once it has data),
+/// and both Claude and Codex show their reasoning-effort mix and their
+/// granted-autonomy mix (the `autonomy` row: `permissionMode` /
+/// `approval_policy`). Deliberately
+/// small (a few rows): the dials are asymmetric across providers, so each
+/// tab renders only its own rows.
 pub(in crate::ui) fn modes_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
     let modes = &summary.modes;
     if modes.is_empty() {
@@ -49,29 +51,109 @@ pub(in crate::ui) fn modes_lines(summary: &Summary, width: u16) -> Vec<Line<'sta
     }
 
     if !modes.efforts.is_empty() {
-        let total: usize = modes.efforts.iter().map(|(_, count)| count).sum();
-        let total = u64::try_from(total).unwrap_or(1).max(1);
-        let mut spans = vec![Span::styled("effort    ", Style::default().fg(theme::TEXT))];
-        for (index, (label, count)) in modes.efforts.iter().take(3).enumerate() {
-            if index > 0 {
-                spans.push(Span::styled(" · ", Style::default().fg(theme::DIM)));
-            }
-            let style = if index == 0 {
-                Style::default()
-                    .fg(theme::TEXT)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(theme::MUTED)
-            };
+        lines.push(mix_line("effort    ", &modes.efforts, 3, width));
+    }
+
+    if !modes.permissions.is_empty() {
+        let display: Vec<(String, usize)> = modes
+            .permissions
+            .iter()
+            .map(|(label, count)| {
+                let display = match label.as_str() {
+                    "acceptEdits" => "edits",
+                    "bypassPermissions" => "bypass",
+                    other => other,
+                };
+                (display.to_owned(), *count)
+            })
+            .collect();
+        lines.push(mix_line("autonomy  ", &display, 2, width));
+    }
+
+    lines
+}
+
+/// One label-plus-entries row (`effort    xhigh 98.2% · max 0.3%`): top
+/// `max_entries` labels with their share, fitted to the rail — an entry that
+/// would overflow `width` is dropped whole, never clipped mid-label.
+fn mix_line(
+    label: &'static str,
+    entries: &[(String, usize)],
+    max_entries: usize,
+    width: u16,
+) -> Line<'static> {
+    let total: usize = entries.iter().map(|(_, count)| count).sum();
+    let total = u64::try_from(total).unwrap_or(1).max(1);
+    let mut spans = vec![Span::styled(label, Style::default().fg(theme::TEXT))];
+    let mut used = label.len();
+    for (index, (name, count)) in entries.iter().take(max_entries).enumerate() {
+        let separator = if index == 0 { "" } else { " · " };
+        let entry = format!(
+            "{name} {}",
+            format_percent(u64::try_from(*count).unwrap_or(0), total)
+        );
+        if index > 0 && used + separator.len() + entry.len() > usize::from(width) {
+            break;
+        }
+        used += separator.len() + entry.len();
+        if !separator.is_empty() {
             spans.push(Span::styled(
-                format!(
-                    "{label} {}",
-                    format_percent(u64::try_from(*count).unwrap_or(0), total)
-                ),
-                style,
+                separator.to_owned(),
+                Style::default().fg(theme::DIM),
             ));
         }
-        lines.push(Line::from(spans));
+        let style = if index == 0 {
+            Style::default()
+                .fg(theme::TEXT)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme::MUTED)
+        };
+        spans.push(Span::styled(entry, style));
     }
-    lines
+    Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ModesSummary, Summary};
+
+    fn summary_with_permissions(permissions: Vec<(String, usize)>) -> Summary {
+        let mut summary = crate::share::fixtures::sample_summary();
+        summary.modes = ModesSummary {
+            assistant_turns: 0,
+            thinking_turns: 0,
+            fast_turns: 0,
+            efforts: Vec::new(),
+            permissions,
+        };
+        summary
+    }
+
+    fn rendered(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    /// The 80-column layout gives the right rail ~34 columns; long Codex
+    /// labels must drop the second entry instead of clipping mid-label.
+    #[test]
+    fn permission_row_fits_a_narrow_rail_by_dropping_entries() {
+        let summary = summary_with_permissions(vec![
+            ("on-request".to_owned(), 50),
+            ("never".to_owned(), 50),
+        ]);
+        let narrow = modes_lines(&summary, 34);
+        let row = rendered(narrow.last().expect("permission row should render"));
+        assert!(row.len() <= 34, "row overflows the rail: {row:?}");
+        assert!(row.contains("on-request"));
+        assert!(!row.contains("never"));
+
+        let wide = modes_lines(&summary, 80);
+        let row = rendered(wide.last().expect("permission row should render"));
+        assert!(row.contains("on-request") && row.contains("never"));
+    }
 }


### PR DESCRIPTION
## Summary

MODES could show how the model thinks (thinking fire rate, effort mix) but not how much it is allowed to act unattended — the missing third dial of driving style. This adds a granted-autonomy mix for both providers, rendered as one `autonomy` row with the top two modes.

Per area, at a glance:

- **Claude collector**: one event per **human turn** from the top-level `permissionMode`, gated on `is_human_turn` — cross-session agent messages (`isMeta`) also carry the field (2.5% of carriers in real logs) and would swamp orchestration-heavy windows. Keyed `claude-permission:{uuid}` so resume/fork row copies dedupe. The `type:"permission-mode"` change-stream rows are deliberately unused: per-turn values give the distribution, not just switch points.
- **Codex collector**: `turn_context.approval_policy` inside the replay-burst guard, keyed `codex-permission:v2:{sid}:{turn_id}` with the positional fallback older rollouts need.
- **Model / merge / analyzer**: `PermissionEvent` mirrors the effort-event machinery end to end (keyed dedupe with older-timestamp merge, window-filtered distribution into `ModesSummary.permissions`).
- **UI**: the `autonomy` row and the effort row now share one width-fitted `mix_line()` builder that drops whole entries on narrow rails instead of clipping mid-label — this also fixes a latent effort-row overflow and a one-column label misalignment.
- **Cache**: `CACHE_VERSION` 14 → 15 (`FileEvents` layout change; older caches would otherwise stay permanently autonomy-less).

## Test Plan

- 151 tests green, clippy pedantic clean. New coverage: uuid dedup incl. the `isMeta` exclusion, Codex fixture with `approval_policy`, fork-replay assertions (permissions skip the replay burst), analyzer window filtering, and rail fitting at 34/80 columns.
- Real-log verification: `permissionMode` appears only on human-turn rows (426/426 sampled); TUI checked against live data.
- Review loop before this PR: three codex rounds plus architecture and code evaluators — all findings applied, final round clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)