### PR TITLE
COMPLETION: count user-interrupted turns

### DIFF
--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -150,6 +150,8 @@ pub fn summarize(
         duration::longest_session_span(collection, period_start, period_end, local_offset);
     let completion_duration =
         duration::completion_duration_summary(collection, period_start, period_end, local_offset);
+    let interrupted =
+        duration::interrupted_count(collection, period_start, period_end, local_offset);
     let orchestration =
         concurrency::orchestration(collection, period_start, period_end, local_offset);
     let (longest_streak_days, current_streak_days) =
@@ -243,6 +245,7 @@ pub fn summarize(
         favorite_model,
         longest_session,
         completion_duration,
+        interrupted,
         orchestration,
     }
 }
@@ -300,28 +303,16 @@ mod tests {
 
     use super::*;
     use crate::model::{
-        Collection, InterruptEvent, Provider, ScanStats, SessionTouch, SourceKind, TokenUsage,
-        UsageEvent,
+        Collection, InterruptEvent, Provider, SessionTouch, SourceKind, TokenUsage, UsageEvent,
     };
 
-    /// A window with interruptions but no completed turn still yields a
-    /// summary (all-zero duration stats) so the count stays visible under a
-    /// short `--days`; undated or out-of-window interrupts are excluded.
+    /// Interruptions are independent of completed-turn stats: a window with
+    /// interruptions but no completed turn reports the count and no duration
+    /// summary; undated or out-of-window interrupts are excluded.
     #[test]
-    fn interrupt_only_window_still_summarizes() {
+    fn interruptions_are_counted_independently_of_durations() {
         let now = datetime!(2026-06-08 12:00 UTC);
         let collection = Collection {
-            provider: Provider::Claude,
-            root: "/tmp".into(),
-            usage_events: Vec::new(),
-            tool_events: Vec::new(),
-            session_touches: Vec::new(),
-            duration_events: Vec::new(),
-            rate_limit_samples: Vec::new(),
-            credit_samples: Vec::new(),
-            effort_events: Vec::new(),
-            mode_events: Vec::new(),
-            permission_events: Vec::new(),
             interrupt_events: vec![
                 InterruptEvent {
                     timestamp: Some(datetime!(2026-06-07 10:00 UTC)),
@@ -331,25 +322,21 @@ mod tests {
                 },
                 InterruptEvent { timestamp: None },
             ],
-            stats: ScanStats::default(),
+            ..Collection::new(Provider::Claude, "/tmp".into())
         };
 
         let summary = summarize(&collection, now, 7, UtcOffset::UTC);
 
-        let duration = summary
-            .completion_duration
-            .expect("interrupt-only window should keep the count visible");
-        assert_eq!(duration.count, 0);
-        assert_eq!(duration.interrupted, 1);
-        assert_eq!(duration.p50_ms, 0);
+        // No completed turn → no duration stats; the interruption count is
+        // its own metric and stays visible regardless.
+        assert!(summary.completion_duration.is_none());
+        assert_eq!(summary.interrupted, 1);
     }
 
     #[test]
     fn aggregates_models_agents_tools_and_streaks() {
         let now = datetime!(2026-06-08 12:00 UTC);
         let collection = Collection {
-            provider: Provider::Claude,
-            root: "/tmp/claude".into(),
             usage_events: vec![
                 UsageEvent {
                     timestamp: Some(datetime!(2026-06-07 10:00 UTC)),
@@ -415,14 +402,7 @@ mod tests {
                     session_id: "s1".to_owned(),
                 },
             ],
-            duration_events: Vec::new(),
-            rate_limit_samples: Vec::new(),
-            credit_samples: Vec::new(),
-            effort_events: Vec::new(),
-            mode_events: Vec::new(),
-            permission_events: Vec::new(),
-            interrupt_events: Vec::new(),
-            stats: ScanStats::default(),
+            ..Collection::new(Provider::Claude, "/tmp/claude".into())
         };
 
         let summary = summarize(&collection, now, 7, UtcOffset::UTC);
@@ -469,19 +449,8 @@ mod tests {
             event(datetime!(2026-05-21 10:00 UTC), 4_000_000), // only the 90d display
         ];
         let collection = |events: Vec<UsageEvent>| Collection {
-            provider: Provider::Claude,
-            root: "/tmp".into(),
             usage_events: events,
-            tool_events: Vec::new(),
-            session_touches: Vec::new(),
-            duration_events: Vec::new(),
-            rate_limit_samples: Vec::new(),
-            credit_samples: Vec::new(),
-            effort_events: Vec::new(),
-            mode_events: Vec::new(),
-            permission_events: Vec::new(),
-            interrupt_events: Vec::new(),
-            stats: ScanStats::default(),
+            ..Collection::new(Provider::Claude, "/tmp".into())
         };
 
         let week = summarize(&collection(events.clone()), now, 7, UtcOffset::UTC);
@@ -518,19 +487,8 @@ mod tests {
             reported_cost_usd: reported,
         };
         let collection = Collection {
-            provider: Provider::Combined,
-            root: "/tmp".into(),
             usage_events: vec![event(Some(0.5), 100), event(None, 300)],
-            tool_events: Vec::new(),
-            session_touches: Vec::new(),
-            duration_events: Vec::new(),
-            rate_limit_samples: Vec::new(),
-            credit_samples: Vec::new(),
-            effort_events: Vec::new(),
-            mode_events: Vec::new(),
-            permission_events: Vec::new(),
-            interrupt_events: Vec::new(),
-            stats: ScanStats::default(),
+            ..Collection::new(Provider::Combined, "/tmp".into())
         };
 
         let summary = summarize(&collection, now, 7, UtcOffset::UTC);
@@ -561,8 +519,8 @@ mod v09_tests {
     use super::*;
     use crate::model::LimitDay;
     use crate::model::{
-        Collection, EffortEvent, ModeEvent, PermissionEvent, Provider, RateLimitSample, ScanStats,
-        SourceKind, UsageEvent,
+        Collection, EffortEvent, ModeEvent, PermissionEvent, Provider, RateLimitSample, SourceKind,
+        UsageEvent,
     };
 
     fn skill_event(at: OffsetDateTime, skill: Option<&str>, tokens: u64) -> UsageEvent {
@@ -589,8 +547,6 @@ mod v09_tests {
     fn v09_sections_use_fixed_window_and_tristate_days() {
         let now = datetime!(2026-06-30 12:00 UTC);
         let collection = Collection {
-            provider: Provider::Combined,
-            root: "/tmp".into(),
             usage_events: vec![
                 // In the 30d window (06-01..06-30) with a skill.
                 skill_event(
@@ -608,10 +564,6 @@ mod v09_tests {
                 // Active day without any rate-limit sample -> NoSample.
                 skill_event(datetime!(2026-06-22 09:00 UTC), None, 500),
             ],
-            tool_events: Vec::new(),
-            session_touches: Vec::new(),
-            duration_events: Vec::new(),
-            credit_samples: Vec::new(),
             rate_limit_samples: vec![
                 RateLimitSample {
                     timestamp: datetime!(2026-06-22 08:00 UTC),
@@ -679,8 +631,7 @@ mod v09_tests {
                     mode: "default".to_owned(),
                 },
             ],
-            interrupt_events: Vec::new(),
-            stats: ScanStats::default(),
+            ..Collection::new(Provider::Combined, "/tmp".into())
         };
 
         let summary = summarize(&collection, now, 90, UtcOffset::UTC);

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -380,6 +380,7 @@ mod tests {
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             permission_events: Vec::new(),
+            interrupt_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -438,6 +439,7 @@ mod tests {
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             permission_events: Vec::new(),
+            interrupt_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -486,6 +488,7 @@ mod tests {
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             permission_events: Vec::new(),
+            interrupt_events: Vec::new(),
             stats: ScanStats::default(),
         };
 
@@ -635,6 +638,7 @@ mod v09_tests {
                     mode: "default".to_owned(),
                 },
             ],
+            interrupt_events: Vec::new(),
             stats: ScanStats::default(),
         };
 

--- a/src/analyzer.rs
+++ b/src/analyzer.rs
@@ -300,8 +300,49 @@ mod tests {
 
     use super::*;
     use crate::model::{
-        Collection, Provider, ScanStats, SessionTouch, SourceKind, TokenUsage, UsageEvent,
+        Collection, InterruptEvent, Provider, ScanStats, SessionTouch, SourceKind, TokenUsage,
+        UsageEvent,
     };
+
+    /// A window with interruptions but no completed turn still yields a
+    /// summary (all-zero duration stats) so the count stays visible under a
+    /// short `--days`; undated or out-of-window interrupts are excluded.
+    #[test]
+    fn interrupt_only_window_still_summarizes() {
+        let now = datetime!(2026-06-08 12:00 UTC);
+        let collection = Collection {
+            provider: Provider::Claude,
+            root: "/tmp".into(),
+            usage_events: Vec::new(),
+            tool_events: Vec::new(),
+            session_touches: Vec::new(),
+            duration_events: Vec::new(),
+            rate_limit_samples: Vec::new(),
+            credit_samples: Vec::new(),
+            effort_events: Vec::new(),
+            mode_events: Vec::new(),
+            permission_events: Vec::new(),
+            interrupt_events: vec![
+                InterruptEvent {
+                    timestamp: Some(datetime!(2026-06-07 10:00 UTC)),
+                },
+                InterruptEvent {
+                    timestamp: Some(datetime!(2026-01-01 10:00 UTC)),
+                },
+                InterruptEvent { timestamp: None },
+            ],
+            stats: ScanStats::default(),
+        };
+
+        let summary = summarize(&collection, now, 7, UtcOffset::UTC);
+
+        let duration = summary
+            .completion_duration
+            .expect("interrupt-only window should keep the count visible");
+        assert_eq!(duration.count, 0);
+        assert_eq!(duration.interrupted, 1);
+        assert_eq!(duration.p50_ms, 0);
+    }
 
     #[test]
     fn aggregates_models_agents_tools_and_streaks() {

--- a/src/analyzer/concurrency.rs
+++ b/src/analyzer/concurrency.rs
@@ -137,6 +137,7 @@ mod tests {
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             permission_events: Vec::new(),
+            interrupt_events: Vec::new(),
             stats: ScanStats::default(),
         }
     }

--- a/src/analyzer/concurrency.rs
+++ b/src/analyzer/concurrency.rs
@@ -115,7 +115,7 @@ mod tests {
     use time::OffsetDateTime;
     use time::macros::datetime;
 
-    use crate::model::{Collection, Provider, ScanStats, SessionTouch};
+    use crate::model::{Collection, Provider, SessionTouch};
 
     fn touch(session: &str, at: OffsetDateTime) -> SessionTouch {
         SessionTouch {
@@ -126,19 +126,8 @@ mod tests {
 
     fn collection(touches: Vec<SessionTouch>) -> Collection {
         Collection {
-            provider: Provider::Claude,
-            root: "/tmp".into(),
-            usage_events: Vec::new(),
-            tool_events: Vec::new(),
             session_touches: touches,
-            duration_events: Vec::new(),
-            rate_limit_samples: Vec::new(),
-            credit_samples: Vec::new(),
-            effort_events: Vec::new(),
-            mode_events: Vec::new(),
-            permission_events: Vec::new(),
-            interrupt_events: Vec::new(),
-            stats: ScanStats::default(),
+            ..Collection::new(Provider::Claude, "/tmp".into())
         }
     }
 

--- a/src/analyzer/duration.rs
+++ b/src/analyzer/duration.rs
@@ -36,12 +36,8 @@ pub(super) fn longest_session_span(
         .max_by_key(SessionSpan::duration_secs)
 }
 
-/// Summarize completed-turn durations plus the window's interruption count.
-/// A window holding interruptions but no completed turn (realistic under a
-/// short `--days`) still yields a summary — all-zero duration stats — so
-/// the count stays visible. Interrupts count only when dated inside the
-/// window (the same `is_some_and` ruling as the mode summaries): an
-/// undated event would otherwise appear in every requested window.
+/// Summarize completed-turn durations; `None` when no turn completed in the
+/// window. Interruptions are a separate metric — see `interrupted_count`.
 pub(super) fn completion_duration_summary(
     collection: &Collection,
     period_start: Date,
@@ -60,23 +56,12 @@ pub(super) fn completion_duration_summary(
         .map(|event| event.duration_ms)
         .filter(|duration_ms| *duration_ms > 0)
         .collect::<Vec<_>>();
-    let interrupted = collection
-        .interrupt_events
-        .iter()
-        .filter(|event| {
-            event
-                .timestamp
-                .map(|timestamp| timestamp.to_offset(local_offset).date())
-                .is_some_and(|date| date >= period_start && date <= period_end)
-        })
-        .count();
-    if values.is_empty() && interrupted == 0 {
+    if values.is_empty() {
         return None;
     }
     values.sort_unstable();
     Some(DurationSummary {
         count: values.len(),
-        interrupted,
         p50_ms: percentile_ms(&values, 50),
         p90_ms: percentile_ms(&values, 90),
         p95_ms: percentile_ms(&values, 95),
@@ -85,10 +70,28 @@ pub(super) fn completion_duration_summary(
     })
 }
 
+/// User interruptions dated inside the window. Only dated events count
+/// (the same `is_some_and` ruling as the mode summaries): an undated event
+/// would otherwise appear in every requested window.
+pub(super) fn interrupted_count(
+    collection: &Collection,
+    period_start: Date,
+    period_end: Date,
+    local_offset: UtcOffset,
+) -> usize {
+    collection
+        .interrupt_events
+        .iter()
+        .filter(|event| {
+            event
+                .timestamp
+                .map(|timestamp| timestamp.to_offset(local_offset).date())
+                .is_some_and(|date| date >= period_start && date <= period_end)
+        })
+        .count()
+}
+
 fn percentile_ms(sorted_values: &[u64], percentile: usize) -> u64 {
-    if sorted_values.is_empty() {
-        return 0;
-    }
     let rank = sorted_values.len().saturating_mul(percentile).div_ceil(100);
     let index = rank.saturating_sub(1).min(sorted_values.len() - 1);
     sorted_values[index]

--- a/src/analyzer/duration.rs
+++ b/src/analyzer/duration.rs
@@ -37,10 +37,11 @@ pub(super) fn longest_session_span(
 }
 
 /// Summarize completed-turn durations plus the window's interruption count.
-/// A window with zero completed turns returns `None` even if interruptions
-/// exist — the COMPLETION section disappears with them, which is accepted:
-/// a fixed 30-day window without a single completed turn does not occur in
-/// real use.
+/// A window holding interruptions but no completed turn (realistic under a
+/// short `--days`) still yields a summary — all-zero duration stats — so
+/// the count stays visible. Interrupts count only when dated inside the
+/// window (the same `is_some_and` ruling as the mode summaries): an
+/// undated event would otherwise appear in every requested window.
 pub(super) fn completion_duration_summary(
     collection: &Collection,
     period_start: Date,
@@ -59,20 +60,20 @@ pub(super) fn completion_duration_summary(
         .map(|event| event.duration_ms)
         .filter(|duration_ms| *duration_ms > 0)
         .collect::<Vec<_>>();
-    if values.is_empty() {
-        return None;
-    }
-    values.sort_unstable();
     let interrupted = collection
         .interrupt_events
         .iter()
         .filter(|event| {
-            event.timestamp.is_none_or(|timestamp| {
-                let date = timestamp.to_offset(local_offset).date();
-                date >= period_start && date <= period_end
-            })
+            event
+                .timestamp
+                .map(|timestamp| timestamp.to_offset(local_offset).date())
+                .is_some_and(|date| date >= period_start && date <= period_end)
         })
         .count();
+    if values.is_empty() && interrupted == 0 {
+        return None;
+    }
+    values.sort_unstable();
     Some(DurationSummary {
         count: values.len(),
         interrupted,
@@ -85,6 +86,9 @@ pub(super) fn completion_duration_summary(
 }
 
 fn percentile_ms(sorted_values: &[u64], percentile: usize) -> u64 {
+    if sorted_values.is_empty() {
+        return 0;
+    }
     let rank = sorted_values.len().saturating_mul(percentile).div_ceil(100);
     let index = rank.saturating_sub(1).min(sorted_values.len() - 1);
     sorted_values[index]

--- a/src/analyzer/duration.rs
+++ b/src/analyzer/duration.rs
@@ -36,6 +36,11 @@ pub(super) fn longest_session_span(
         .max_by_key(SessionSpan::duration_secs)
 }
 
+/// Summarize completed-turn durations plus the window's interruption count.
+/// A window with zero completed turns returns `None` even if interruptions
+/// exist — the COMPLETION section disappears with them, which is accepted:
+/// a fixed 30-day window without a single completed turn does not occur in
+/// real use.
 pub(super) fn completion_duration_summary(
     collection: &Collection,
     period_start: Date,
@@ -58,8 +63,19 @@ pub(super) fn completion_duration_summary(
         return None;
     }
     values.sort_unstable();
+    let interrupted = collection
+        .interrupt_events
+        .iter()
+        .filter(|event| {
+            event.timestamp.is_none_or(|timestamp| {
+                let date = timestamp.to_offset(local_offset).date();
+                date >= period_start && date <= period_end
+            })
+        })
+        .count();
     Some(DurationSummary {
         count: values.len(),
+        interrupted,
         p50_ms: percentile_ms(&values, 50),
         p90_ms: percentile_ms(&values, 90),
         p95_ms: percentile_ms(&values, 95),

--- a/src/app.rs
+++ b/src/app.rs
@@ -212,17 +212,18 @@ fn collect_all(config: &Config, mtime_floor: Option<SystemTime>) -> Result<Vec<C
 }
 
 /// A provider earns a tab only if it has real activity. Token volume catches
-/// most agents; sessions, tools, completions, and the fixed-window credit
-/// ledger are the fallback for a session that logged activity but no usage
-/// tokens (Copilot credits cut on the fixed 30-day window, so they can exist
-/// even when a short `--days` display window is empty). Everything false ⇒
-/// the directory was missing or empty, so the tab is dropped instead of
-/// showing a blank tab.
+/// most agents; sessions, tools, completions, interruptions, and the
+/// fixed-window credit ledger are the fallback for a session that logged
+/// activity but no usage tokens (Copilot credits cut on the fixed 30-day
+/// window, so they can exist even when a short `--days` display window is
+/// empty). Everything false ⇒ the directory was missing or empty, so the tab
+/// is dropped instead of showing a blank tab.
 fn provider_has_data(summary: &crate::model::Summary) -> bool {
     summary.total_usage.token_volume() > 0
         || summary.sessions > 0
         || !summary.tools.is_empty()
         || summary.completion_duration.is_some()
+        || summary.interrupted > 0
         || summary.credits.is_some()
 }
 
@@ -332,6 +333,7 @@ mod tests {
             favorite_model: None,
             longest_session: None,
             completion_duration: None,
+            interrupted: 0,
             orchestration: Orchestration::default(),
         }
     }
@@ -358,12 +360,17 @@ mod tests {
 
     #[test]
     fn empty_provider_has_no_tab() {
-        // A provider with no tokens, sessions, tools, or completions (a missing
-        // or empty log dir) must not earn a tab.
+        // A provider with no tokens, sessions, tools, completions, or
+        // interruptions (a missing or empty log dir) must not earn a tab.
         let empty = provider_summary(Provider::Codex, "gpt-5.5", 0);
         assert!(!provider_has_data(&empty));
 
         let used = provider_summary(Provider::Claude, "claude-opus-4-8", 1);
         assert!(provider_has_data(&used));
+
+        // Interruptions alone are activity: an all-aborted window keeps the tab.
+        let mut interrupted_only = provider_summary(Provider::Codex, "gpt-5.5", 0);
+        interrupted_only.interrupted = 2;
+        assert!(provider_has_data(&interrupted_only));
     }
 }

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -21,8 +21,8 @@ mod walk;
 
 pub use cache::parse_files_cached;
 pub use events::{
-    FileEvents, KeyedCreditSample, KeyedDurationEvent, KeyedEffortEvent, KeyedModeEvent,
-    KeyedPermissionEvent, KeyedRateLimitSample, KeyedToolEvent, KeyedUsageEvent,
+    FileEvents, KeyedCreditSample, KeyedDurationEvent, KeyedEffortEvent, KeyedInterruptEvent,
+    KeyedModeEvent, KeyedPermissionEvent, KeyedRateLimitSample, KeyedToolEvent, KeyedUsageEvent,
 };
 pub use merge::merge_into;
 pub use project::project_from_cwd;

--- a/src/collector/cache.rs
+++ b/src/collector/cache.rs
@@ -37,9 +37,12 @@ use super::events::FileEvents;
 ///   its bincode layout.
 /// - 16: `FileEvents` gained `interrupt_events` (esc / `turn_aborted` counts),
 ///   changing its bincode layout.
+/// - 17: interrupt admission tightened (exact Claude marker forms, subagent
+///   file provenance, Codex `reason == "interrupted"` + required `turn_id`)
+///   — v16 caches carry over-counted interrupt events.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
-const CACHE_VERSION: u32 = 16;
+const CACHE_VERSION: u32 = 17;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct FileStamp {

--- a/src/collector/cache.rs
+++ b/src/collector/cache.rs
@@ -37,9 +37,10 @@ use super::events::FileEvents;
 ///   its bincode layout.
 /// - 16: `FileEvents` gained `interrupt_events` (esc / `turn_aborted` counts),
 ///   changing its bincode layout.
-/// - 17: interrupt admission tightened (exact Claude marker forms, subagent
-///   file provenance, Codex `reason == "interrupted"` + required `turn_id`)
-///   — v16 caches carry over-counted interrupt events.
+/// - 17: interrupt admission tightened (exact Claude marker forms as the
+///   sole content block, subagent file provenance, Codex
+///   `reason == "interrupted"` + required `turn_id`) — v16 caches carry
+///   over-counted interrupt events.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
 const CACHE_VERSION: u32 = 17;

--- a/src/collector/cache.rs
+++ b/src/collector/cache.rs
@@ -35,9 +35,11 @@ use super::events::FileEvents;
 ///   but carry empty effort events for already-parsed sessions.
 /// - 15: `FileEvents` gained `permission_events` (autonomy mix), changing
 ///   its bincode layout.
+/// - 16: `FileEvents` gained `interrupt_events` (esc / `turn_aborted` counts),
+///   changing its bincode layout.
 ///
 /// The per-file key remains (mtime, size); `--no-cache` is never required.
-const CACHE_VERSION: u32 = 15;
+const CACHE_VERSION: u32 = 16;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 struct FileStamp {

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -8,12 +8,13 @@ use time::format_description::well_known::Rfc3339;
 use time::{Duration, OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedModeEvent, KeyedPermissionEvent,
-    KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached, project_from_cwd,
+    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedInterruptEvent, KeyedModeEvent,
+    KeyedPermissionEvent, KeyedToolEvent, KeyedUsageEvent, list_files, merge_into,
+    parse_files_cached, project_from_cwd,
 };
 use crate::model::{
-    Collection, DurationEvent, EffortEvent, ModeEvent, PermissionEvent, Provider, SessionTouch,
-    SourceKind, TokenUsage, ToolEvent, UsageEvent,
+    Collection, DurationEvent, EffortEvent, InterruptEvent, ModeEvent, PermissionEvent, Provider,
+    SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
 };
 
 /// Background/observer harnesses (e.g. the claude-mem observer) keep
@@ -125,7 +126,14 @@ fn parse_file(path: &Path, root: &Path, local_offset: UtcOffset) -> Option<FileE
         if source_kind == SourceKind::Main
             && let Some(timestamp) = parse_timestamp(value.get("timestamp"))
         {
-            if is_human_turn(&value) {
+            if is_interrupt_marker(&value) {
+                // The active turn was aborted: discard it (completion stats
+                // count completed turns only, matching Codex where
+                // `turn_aborted` never reaches the durations) and don't
+                // start a bogus turn from the marker row itself.
+                turn_start = None;
+                last_activity = None;
+            } else if is_human_turn(&value) {
                 push_turn_duration(turn_start, last_activity, &mut events);
                 turn_start = Some(timestamp);
                 last_activity = Some(timestamp);
@@ -268,6 +276,7 @@ fn parse_line(
     collect_mode_event(value, message, timestamp, events);
     collect_effort_event(value, message, timestamp, events);
     collect_permission_event(value, timestamp, events);
+    collect_interrupt_event(value, timestamp, events);
 
     let usage_value = message.get("usage").or_else(|| value.get("usage"));
     let message_id = string_field(message, "id");
@@ -402,6 +411,63 @@ fn collect_permission_event(
     events.permission_events.push(KeyedPermissionEvent {
         key: Some(format!("claude-permission:{uuid}")),
         event: PermissionEvent { timestamp, mode },
+    });
+}
+
+/// A main-thread row the harness writes when the user hits esc: a user row
+/// whose content starts with a `[Request interrupted by user …]` marker.
+/// `isMeta` rows are excluded because agent messages QUOTING the marker
+/// would otherwise count. `isSidechain` rows are excluded because one esc
+/// against a parallel team fans out as marker echoes into every subagent
+/// transcript (bursts of 10-16 observed — counting them would overstate
+/// interruptions ~1.8x, load-dependently). The trade-off: an esc recorded
+/// only in sidechain files (~14% of esc moments) is deliberately not
+/// counted — the same turn-level ruling as Codex, where `turn_aborted`
+/// is used and `sub_agent_activity: interrupted` is discarded.
+fn is_interrupt_marker(value: &Value) -> bool {
+    if value.get("type").and_then(Value::as_str) != Some("user") {
+        return false;
+    }
+    let flagged = |field: &str| value.get(field).and_then(Value::as_bool).unwrap_or(false);
+    if flagged("isMeta") || flagged("isSidechain") {
+        return false;
+    }
+    let is_marker = |text: &str| {
+        text.trim_start()
+            .starts_with("[Request interrupted by user")
+    };
+    match value
+        .get("message")
+        .and_then(|message| message.get("content"))
+    {
+        Some(Value::String(text)) => is_marker(text),
+        Some(Value::Array(blocks)) => blocks.iter().any(|block| {
+            block
+                .get("text")
+                .and_then(Value::as_str)
+                .is_some_and(is_marker)
+        }),
+        _ => false,
+    }
+}
+
+/// One interrupt event per main-thread esc (`interruptedMessageId` rows are
+/// a strict subset of marker rows, so the marker alone carries the count).
+/// Keyed by the row uuid, which resume/fork copies share.
+fn collect_interrupt_event(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    events: &mut FileEvents,
+) {
+    if !is_interrupt_marker(value) {
+        return;
+    }
+    let Some(uuid) = string_field(value, "uuid") else {
+        return;
+    };
+    events.interrupt_events.push(KeyedInterruptEvent {
+        key: Some(format!("claude-interrupt:{uuid}")),
+        event: InterruptEvent { timestamp },
     });
 }
 
@@ -693,6 +759,74 @@ mod tests {
         assert!(collection.mode_events[0].fast);
         assert!(!collection.mode_events[1].has_thinking);
         assert!(!collection.mode_events[1].fast);
+    }
+
+    /// Interrupt markers count once per esc: duplicate uuids (resume/fork
+    /// copies) dedupe, block-content markers count, and a row carrying only
+    /// `interruptedMessageId` without the marker does not count (real logs
+    /// show such rows always carry the marker too).
+    #[test]
+    fn collects_interrupt_events_from_marker_rows() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-07-20T00:00:00Z","sessionId":"s1","type":"user","uuid":"i1","message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:00:00Z","sessionId":"s1","type":"user","uuid":"i1","message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:01:00Z","sessionId":"s1","type":"user","uuid":"i2","message":{"role":"user","content":[{"type":"text","text":"[Request interrupted by user for tool use]"}]}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:02:00Z","sessionId":"s1","type":"user","uuid":"i3","interruptedMessageId":"m9","message":{"role":"user","content":"a plain follow-up"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:03:00Z","sessionId":"s1","type":"user","uuid":"i4","isMeta":true,"message":{"role":"user","content":"[Request interrupted by user] quoted in an agent report"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:04:00Z","sessionId":"s1","type":"user","uuid":"i5","message":{"role":"user","content":"the log said [Request interrupted by user] mid-sentence"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:05:00Z","sessionId":"s1","type":"user","uuid":"i6","isSidechain":true,"message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.interrupt_events.len(), 2);
+    }
+
+    /// An interrupted turn is discarded from completion durations (matching
+    /// Codex, where `turn_aborted` never reaches the durations), and the
+    /// marker row does not start a bogus turn of its own.
+    #[test]
+    fn interrupted_turns_are_excluded_from_durations() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-07-20T00:00:00Z","sessionId":"s1","type":"user","uuid":"h1","message":{"role":"user","content":"do the thing"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:01:00Z","sessionId":"s1","type":"assistant","message":{"id":"a1","model":"claude-fable-5","usage":{"input_tokens":5,"output_tokens":2},"content":[{"type":"text","text":"working"}]}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:02:00Z","sessionId":"s1","type":"user","uuid":"i1","message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:05:00Z","sessionId":"s1","type":"user","uuid":"h2","message":{"role":"user","content":"try again"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:06:00Z","sessionId":"s1","type":"assistant","message":{"id":"a2","model":"claude-fable-5","usage":{"input_tokens":5,"output_tokens":2},"content":[{"type":"text","text":"done"}]}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:07:00Z","sessionId":"s1","type":"user","uuid":"h3","message":{"role":"user","content":"thanks"}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        assert_eq!(collection.interrupt_events.len(), 1);
+        // Only the completed turn survives ("try again" 00:05 -> last
+        // activity "done" 00:06 = 60s); the aborted first turn and the
+        // marker row contribute no durations.
+        assert_eq!(collection.duration_events.len(), 1);
+        assert_eq!(collection.duration_events[0].duration_ms, 60_000);
     }
 
     /// The top-level `permissionMode` field on user rows becomes one

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -276,7 +276,7 @@ fn parse_line(
     collect_mode_event(value, message, timestamp, events);
     collect_effort_event(value, message, timestamp, events);
     collect_permission_event(value, timestamp, events);
-    collect_interrupt_event(value, timestamp, events);
+    collect_interrupt_event(value, timestamp, source_kind, events);
 
     let usage_value = message.get("usage").or_else(|| value.get("usage"));
     let message_id = string_field(message, "id");
@@ -415,7 +415,9 @@ fn collect_permission_event(
 }
 
 /// A main-thread row the harness writes when the user hits esc: a user row
-/// whose content starts with a `[Request interrupted by user …]` marker.
+/// whose content IS one of the two complete marker forms the harness
+/// emits (the only variants across real logs) — a prompt that merely
+/// quotes or starts with the marker text must not count or clear a turn.
 /// `isMeta` rows are excluded because agent messages QUOTING the marker
 /// would otherwise count. `isSidechain` rows are excluded because one esc
 /// against a parallel team fans out as marker echoes into every subagent
@@ -433,8 +435,10 @@ fn is_interrupt_marker(value: &Value) -> bool {
         return false;
     }
     let is_marker = |text: &str| {
-        text.trim_start()
-            .starts_with("[Request interrupted by user")
+        matches!(
+            text.trim(),
+            "[Request interrupted by user]" | "[Request interrupted by user for tool use]"
+        )
     };
     match value
         .get("message")
@@ -453,12 +457,18 @@ fn is_interrupt_marker(value: &Value) -> bool {
 
 /// One interrupt event per main-thread esc (`interruptedMessageId` rows are
 /// a strict subset of marker rows, so the marker alone carries the count).
-/// Keyed by the row uuid, which resume/fork copies share.
+/// Subagent-file rows are excluded by file provenance too, not only by the
+/// row's `isSidechain` flag. Keyed by the row uuid, which resume/fork
+/// copies share.
 fn collect_interrupt_event(
     value: &Value,
     timestamp: Option<OffsetDateTime>,
+    source_kind: SourceKind,
     events: &mut FileEvents,
 ) {
+    if source_kind != SourceKind::Main {
+        return;
+    }
     if !is_interrupt_marker(value) {
         return;
     }
@@ -784,10 +794,24 @@ mod tests {
                 r#"{"timestamp":"2026-07-20T00:04:00Z","sessionId":"s1","type":"user","uuid":"i5","message":{"role":"user","content":"the log said [Request interrupted by user] mid-sentence"}}"#,
                 "\n",
                 r#"{"timestamp":"2026-07-20T00:05:00Z","sessionId":"s1","type":"user","uuid":"i6","isSidechain":true,"message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:06:00Z","sessionId":"s1","type":"user","uuid":"i7","message":{"role":"user","content":"[Request interrupted by user] what does this marker mean?"}}"#,
                 "\n"
             ),
         )
         .expect("fixture should be written");
+        let subagent_dir = temp.path().join("project").join("subagents");
+        fs::create_dir_all(&subagent_dir).expect("test dirs should be created");
+        // A subagent-file echo that omits the redundant `isSidechain` flag:
+        // file provenance alone must exclude it.
+        fs::write(
+            subagent_dir.join("agent-abc.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-07-20T00:07:00Z","sessionId":"s1","type":"user","uuid":"i8","message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n"
+            ),
+        )
+        .expect("subagent fixture should be written");
 
         let collection = collect(temp.path(), None, false, UtcOffset::UTC);
 

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -123,30 +123,33 @@ fn parse_file(path: &Path, root: &Path, local_offset: UtcOffset) -> Option<FileE
         {
             project = Some(project_from_cwd(&cwd));
         }
-        if source_kind == SourceKind::Main
-            && let Some(timestamp) = parse_timestamp(value.get("timestamp"))
-        {
+        if source_kind == SourceKind::Main {
             if is_interrupt_marker(&value) {
                 // The active turn was aborted: discard it (completion stats
                 // count completed turns only, matching Codex where
                 // `turn_aborted` never reaches the durations) and don't
-                // start a bogus turn from the marker row itself.
+                // start a bogus turn from the marker row itself. Recognized
+                // before requiring a timestamp — an undated marker must
+                // still clear the turn, or the abort would flush as a
+                // completed duration at the next prompt or EOF.
                 turn_start = None;
                 last_activity = None;
-            } else if is_human_turn(&value) {
-                push_turn_duration(turn_start, last_activity, &mut events);
-                turn_start = Some(timestamp);
-                last_activity = Some(timestamp);
-            } else if let Some(previous) = last_activity {
-                // A long silence means the turn ended and the session was
-                // resumed later (compaction, scheduled appends); close the
-                // turn at the last real activity instead of spanning days.
-                if timestamp - previous > Duration::minutes(30) {
+            } else if let Some(timestamp) = parse_timestamp(value.get("timestamp")) {
+                if is_human_turn(&value) {
                     push_turn_duration(turn_start, last_activity, &mut events);
-                    turn_start = None;
-                    last_activity = None;
-                } else {
-                    last_activity = Some(previous.max(timestamp));
+                    turn_start = Some(timestamp);
+                    last_activity = Some(timestamp);
+                } else if let Some(previous) = last_activity {
+                    // A long silence means the turn ended and the session was
+                    // resumed later (compaction, scheduled appends); close the
+                    // turn at the last real activity instead of spanning days.
+                    if timestamp - previous > Duration::minutes(30) {
+                        push_turn_duration(turn_start, last_activity, &mut events);
+                        turn_start = None;
+                        last_activity = None;
+                    } else {
+                        last_activity = Some(previous.max(timestamp));
+                    }
                 }
             }
         }
@@ -857,6 +860,33 @@ mod tests {
         // marker row contribute no durations.
         assert_eq!(collection.duration_events.len(), 1);
         assert_eq!(collection.duration_events[0].duration_ms, 60_000);
+    }
+
+    /// A marker without a timestamp still clears the active turn: the abort
+    /// must not flush as a completed duration at the next prompt or EOF.
+    #[test]
+    fn undated_marker_still_discards_the_aborted_turn() {
+        let temp = TempDir::new().expect("test tempdir should be created");
+        fs::write(
+            temp.path().join("session.jsonl"),
+            concat!(
+                r#"{"timestamp":"2026-07-20T00:00:00Z","sessionId":"s1","type":"user","uuid":"h1","message":{"role":"user","content":"do the thing"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:01:00Z","sessionId":"s1","type":"assistant","message":{"id":"a1","model":"claude-fable-5","usage":{"input_tokens":5,"output_tokens":2},"content":[{"type":"text","text":"working"}]}}"#,
+                "\n",
+                r#"{"sessionId":"s1","type":"user","uuid":"i1","message":{"role":"user","content":"[Request interrupted by user]"}}"#,
+                "\n"
+            ),
+        )
+        .expect("fixture should be written");
+
+        let collection = collect(temp.path(), None, false, UtcOffset::UTC);
+
+        // The undated marker yields an event the analyzer will exclude by
+        // date, and no duration: EOF must not flush the aborted turn.
+        assert_eq!(collection.interrupt_events.len(), 1);
+        assert!(collection.interrupt_events[0].timestamp.is_none());
+        assert_eq!(collection.duration_events.len(), 0);
     }
 
     /// The top-level `permissionMode` field on user rows becomes one

--- a/src/collector/claude.rs
+++ b/src/collector/claude.rs
@@ -440,17 +440,21 @@ fn is_interrupt_marker(value: &Value) -> bool {
             "[Request interrupted by user]" | "[Request interrupted by user for tool use]"
         )
     };
+    // Array content must be SOLELY the marker block (every real marker row
+    // is a single-text array) — a prompt attaching an image alongside a
+    // quoted marker is a real message, not an esc.
     match value
         .get("message")
         .and_then(|message| message.get("content"))
     {
         Some(Value::String(text)) => is_marker(text),
-        Some(Value::Array(blocks)) => blocks.iter().any(|block| {
-            block
+        Some(Value::Array(blocks)) => match blocks.as_slice() {
+            [block] => block
                 .get("text")
                 .and_then(Value::as_str)
-                .is_some_and(is_marker)
-        }),
+                .is_some_and(is_marker),
+            _ => false,
+        },
         _ => false,
     }
 }
@@ -796,6 +800,8 @@ mod tests {
                 r#"{"timestamp":"2026-07-20T00:05:00Z","sessionId":"s1","type":"user","uuid":"i6","isSidechain":true,"message":{"role":"user","content":"[Request interrupted by user]"}}"#,
                 "\n",
                 r#"{"timestamp":"2026-07-20T00:06:00Z","sessionId":"s1","type":"user","uuid":"i7","message":{"role":"user","content":"[Request interrupted by user] what does this marker mean?"}}"#,
+                "\n",
+                r#"{"timestamp":"2026-07-20T00:07:00Z","sessionId":"s1","type":"user","uuid":"i9","message":{"role":"user","content":[{"type":"image","source":{"type":"base64"}},{"type":"text","text":"[Request interrupted by user]"}]}}"#,
                 "\n"
             ),
         )

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -9,12 +9,13 @@ use time::format_description::well_known::Rfc3339;
 use time::{OffsetDateTime, UtcOffset};
 
 use crate::collector::{
-    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedPermissionEvent, KeyedRateLimitSample,
-    KeyedToolEvent, KeyedUsageEvent, list_files, merge_into, parse_files_cached, project_from_cwd,
+    FileEvents, KeyedDurationEvent, KeyedEffortEvent, KeyedInterruptEvent, KeyedPermissionEvent,
+    KeyedRateLimitSample, KeyedToolEvent, KeyedUsageEvent, list_files, merge_into,
+    parse_files_cached, project_from_cwd,
 };
 use crate::model::{
-    Collection, DurationEvent, EffortEvent, PermissionEvent, Provider, RateLimitSample,
-    SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
+    Collection, DurationEvent, EffortEvent, InterruptEvent, PermissionEvent, Provider,
+    RateLimitSample, SessionTouch, SourceKind, TokenUsage, ToolEvent, UsageEvent,
 };
 
 pub fn collect(
@@ -163,6 +164,13 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
             &mut events,
         );
         collect_duration_event(&value, timestamp, current_session_id.as_ref(), &mut events);
+        collect_interrupt_event(
+            &value,
+            timestamp,
+            current_session_id.as_ref(),
+            line_index,
+            &mut events,
+        );
         collect_tool_event(
             &value,
             timestamp,
@@ -321,6 +329,33 @@ fn collect_effort_event(
     events.effort_events.push(KeyedEffortEvent {
         key,
         event: EffortEvent { timestamp, effort },
+    });
+}
+
+/// One interrupt event per `turn_aborted` (reason is always "interrupted").
+/// The same `turn_id` repeats across rollout re-emissions, so events key by
+/// turn id with the positional fallback older rollouts need.
+fn collect_interrupt_event(
+    value: &Value,
+    timestamp: Option<OffsetDateTime>,
+    session_id: Option<&String>,
+    line_index: usize,
+    events: &mut FileEvents,
+) {
+    if value.get("type").and_then(Value::as_str) != Some("event_msg") {
+        return;
+    }
+    if string_path(value, &["payload", "type"]).as_deref() != Some("turn_aborted") {
+        return;
+    }
+    let key = match (session_id, string_path(value, &["payload", "turn_id"])) {
+        (Some(sid), Some(turn_id)) => Some(format!("codex-interrupt:v2:{sid}:{turn_id}")),
+        (Some(sid), None) => positional_key("codex-interrupt", sid, timestamp, line_index),
+        _ => None,
+    };
+    events.interrupt_events.push(KeyedInterruptEvent {
+        key,
+        event: InterruptEvent { timestamp },
     });
 }
 
@@ -728,6 +763,11 @@ mod tests {
                 "\n",
                 // A turn_context without effort contributes no effort event.
                 r#"{"timestamp":"2026-06-01T00:00:04Z","type":"turn_context","payload":{"model":"gpt-5.5"}}"#,
+                "\n",
+                // The same aborted turn re-emitted twice counts once.
+                r#"{"timestamp":"2026-06-01T00:00:05Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","turn_id":"t7","duration_ms":57000}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:06Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","turn_id":"t7","duration_ms":57000}}"#,
                 "\n"
             ),
         )
@@ -739,6 +779,7 @@ mod tests {
         assert_eq!(collection.effort_events[0].effort, "xhigh");
         assert_eq!(collection.permission_events.len(), 1);
         assert_eq!(collection.permission_events[0].mode, "never");
+        assert_eq!(collection.interrupt_events.len(), 1);
         // Only the PRIMARY (5h) window is sampled; the weekly window is
         // deliberately dropped from the LIMITS history.
         assert_eq!(collection.rate_limit_samples.len(), 1);
@@ -794,6 +835,8 @@ mod tests {
             r#"{"timestamp":"2026-06-01T00:00:09Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":0,"output_tokens":20,"total_tokens":140},"total_token_usage":{"input_tokens":220,"cached_input_tokens":40,"output_tokens":30,"total_tokens":250}},"rate_limits":{"primary":{"used_percent":12.5,"window_minutes":300,"resets_at":1750000000}}}}"#,
             "\n",
             r#"{"timestamp":"2026-06-01T00:00:10Z","type":"event_msg","payload":{"type":"task_complete","duration_ms":111}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-01T00:00:11Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","turn_id":"t2","duration_ms":5000}}"#,
             "\n"
         )
     }
@@ -815,6 +858,8 @@ mod tests {
             r#"{"timestamp":"2026-06-01T01:00:00Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":0,"output_tokens":20,"total_tokens":140},"total_token_usage":{"input_tokens":220,"cached_input_tokens":40,"output_tokens":30,"total_tokens":250}},"rate_limits":{"primary":{"used_percent":12.5,"window_minutes":300,"resets_at":1750000000}}}}"#,
             "\n",
             r#"{"timestamp":"2026-06-01T01:00:00Z","type":"event_msg","payload":{"type":"task_complete","duration_ms":111}}"#,
+            "\n",
+            r#"{"timestamp":"2026-06-01T01:00:00Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","turn_id":"t2","duration_ms":5000}}"#,
             "\n",
             r#"{"timestamp":"2026-06-01T01:00:05Z","type":"turn_context","payload":{"model":"gpt-5.5","effort":"xhigh","approval_policy":"never","turn_id":"t9"}}"#,
             "\n",
@@ -839,6 +884,8 @@ mod tests {
         // Replayed task_complete lines are skipped with the burst, so the
         // (unkeyed) duration events cannot double-count.
         assert_eq!(collection.duration_events.len(), 2);
+        // The parent's aborted turn replays in the burst too — one event.
+        assert_eq!(collection.interrupt_events.len(), 1);
 
         // Replayed events keep the parent's ORIGINAL timestamps — day/hour
         // attribution must not shift to the fork instant, whatever the file

--- a/src/collector/codex.rs
+++ b/src/collector/codex.rs
@@ -164,13 +164,7 @@ fn parse_file(path: &Path, local_offset: UtcOffset) -> Option<FileEvents> {
             &mut events,
         );
         collect_duration_event(&value, timestamp, current_session_id.as_ref(), &mut events);
-        collect_interrupt_event(
-            &value,
-            timestamp,
-            current_session_id.as_ref(),
-            line_index,
-            &mut events,
-        );
+        collect_interrupt_event(&value, timestamp, current_session_id.as_ref(), &mut events);
         collect_tool_event(
             &value,
             timestamp,
@@ -332,14 +326,16 @@ fn collect_effort_event(
     });
 }
 
-/// One interrupt event per `turn_aborted` (reason is always "interrupted").
-/// The same `turn_id` repeats across rollout re-emissions, so events key by
-/// turn id with the positional fallback older rollouts need.
+/// One interrupt event per user-caused `turn_aborted`. Other abort reasons
+/// (`replaced`, `review_ended`) are not user escs and never count; every
+/// observed rollout carries the reason field. Events without a `turn_id`
+/// (legacy rollouts only, all predating any 30-day window) are skipped —
+/// a positional fallback is not replay-stable across forks and would
+/// double-count copies, which matters for a counted metric.
 fn collect_interrupt_event(
     value: &Value,
     timestamp: Option<OffsetDateTime>,
     session_id: Option<&String>,
-    line_index: usize,
     events: &mut FileEvents,
 ) {
     if value.get("type").and_then(Value::as_str) != Some("event_msg") {
@@ -348,13 +344,15 @@ fn collect_interrupt_event(
     if string_path(value, &["payload", "type"]).as_deref() != Some("turn_aborted") {
         return;
     }
-    let key = match (session_id, string_path(value, &["payload", "turn_id"])) {
-        (Some(sid), Some(turn_id)) => Some(format!("codex-interrupt:v2:{sid}:{turn_id}")),
-        (Some(sid), None) => positional_key("codex-interrupt", sid, timestamp, line_index),
-        _ => None,
+    if string_path(value, &["payload", "reason"]).as_deref() != Some("interrupted") {
+        return;
+    }
+    let (Some(sid), Some(turn_id)) = (session_id, string_path(value, &["payload", "turn_id"]))
+    else {
+        return;
     };
     events.interrupt_events.push(KeyedInterruptEvent {
-        key,
+        key: Some(format!("codex-interrupt:v2:{sid}:{turn_id}")),
         event: InterruptEvent { timestamp },
     });
 }
@@ -768,6 +766,12 @@ mod tests {
                 r#"{"timestamp":"2026-06-01T00:00:05Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","turn_id":"t7","duration_ms":57000}}"#,
                 "\n",
                 r#"{"timestamp":"2026-06-01T00:00:06Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","turn_id":"t7","duration_ms":57000}}"#,
+                "\n",
+                // A non-user abort reason and a legacy abort without turn_id
+                // are both discarded, not counted as escs.
+                r#"{"timestamp":"2026-06-01T00:00:07Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"replaced","turn_id":"t8","duration_ms":100}}"#,
+                "\n",
+                r#"{"timestamp":"2026-06-01T00:00:08Z","type":"event_msg","payload":{"type":"turn_aborted","reason":"interrupted","duration_ms":200}}"#,
                 "\n"
             ),
         )

--- a/src/collector/events.rs
+++ b/src/collector/events.rs
@@ -5,8 +5,8 @@ use serde::{Deserialize, Serialize};
 use time::{Date, OffsetDateTime, UtcOffset};
 
 use crate::model::{
-    CreditSample, DurationEvent, EffortEvent, ModeEvent, PermissionEvent, RateLimitSample,
-    SessionTouch, ToolEvent, UsageEvent,
+    CreditSample, DurationEvent, EffortEvent, InterruptEvent, ModeEvent, PermissionEvent,
+    RateLimitSample, SessionTouch, ToolEvent, UsageEvent,
 };
 
 /// Events extracted from a single log file. The unit of caching: parsed once,
@@ -22,6 +22,7 @@ pub struct FileEvents {
     pub effort_events: Vec<KeyedEffortEvent>,
     pub mode_events: Vec<KeyedModeEvent>,
     pub permission_events: Vec<KeyedPermissionEvent>,
+    pub interrupt_events: Vec<KeyedInterruptEvent>,
     pub lines_seen: usize,
     pub parse_errors: usize,
 }
@@ -71,6 +72,12 @@ pub struct KeyedEffortEvent {
 pub struct KeyedPermissionEvent {
     pub key: Option<String>,
     pub event: PermissionEvent,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyedInterruptEvent {
+    pub key: Option<String>,
+    pub event: InterruptEvent,
 }
 
 /// Mode event keyed by message id. Duplicate lines for the same message can

--- a/src/collector/merge.rs
+++ b/src/collector/merge.rs
@@ -101,6 +101,7 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
     let mut seen_efforts: HashMap<String, usize> = HashMap::new();
     let mut seen_modes: HashMap<String, usize> = HashMap::new();
     let mut seen_permissions: HashMap<String, usize> = HashMap::new();
+    let mut seen_interrupts: HashMap<String, usize> = HashMap::new();
 
     for (path, events) in per_file {
         collection.stats.files_seen += 1;
@@ -195,6 +196,18 @@ pub fn merge_into(collection: &mut Collection, per_file: Vec<(PathBuf, Option<Fi
             dedupe_into(
                 &mut collection.permission_events,
                 &mut seen_permissions,
+                keyed.key,
+                keyed.event,
+                |existing, incoming| {
+                    existing.timestamp = older_timestamp(existing.timestamp, incoming.timestamp);
+                },
+            );
+        }
+
+        for keyed in events.interrupt_events {
+            dedupe_into(
+                &mut collection.interrupt_events,
+                &mut seen_interrupts,
                 keyed.key,
                 keyed.event,
                 |existing, incoming| {

--- a/src/format.rs
+++ b/src/format.rs
@@ -126,6 +126,19 @@ mod tests {
         assert!(snapshot(&crate::share::fixtures::sample_summary()).contains("rank: unranked"));
     }
 
+    /// An interrupt-only window's summary carries no duration stats — the
+    /// snapshot must not emit a zero-valued `completion_duration:` record.
+    #[test]
+    fn snapshot_suppresses_interrupt_only_completion() {
+        let mut summary = crate::share::fixtures::sample_summary();
+        assert!(snapshot(&summary).contains("completion_duration:"));
+        if let Some(duration) = summary.completion_duration.as_mut() {
+            duration.count = 0;
+            duration.interrupted = 3;
+        }
+        assert!(!snapshot(&summary).contains("completion_duration:"));
+    }
+
     #[test]
     fn formats_tokens_with_compact_units() {
         assert_eq!(format_tokens(900), "900");

--- a/src/format.rs
+++ b/src/format.rs
@@ -127,16 +127,21 @@ mod tests {
     }
 
     /// An interrupt-only window's summary carries no duration stats — the
-    /// snapshot must not emit a zero-valued `completion_duration:` record.
+    /// snapshot must not emit a zero-valued `completion_duration:` record,
+    /// but the interruption count must survive on its own record.
     #[test]
     fn snapshot_suppresses_interrupt_only_completion() {
         let mut summary = crate::share::fixtures::sample_summary();
-        assert!(snapshot(&summary).contains("completion_duration:"));
+        let text = snapshot(&summary);
+        assert!(text.contains("completion_duration:"));
+        assert!(text.contains("completion_interrupted: 0"));
         if let Some(duration) = summary.completion_duration.as_mut() {
             duration.count = 0;
             duration.interrupted = 3;
         }
-        assert!(!snapshot(&summary).contains("completion_duration:"));
+        let text = snapshot(&summary);
+        assert!(!text.contains("completion_duration:"));
+        assert!(text.contains("completion_interrupted: 3"));
     }
 
     #[test]

--- a/src/format.rs
+++ b/src/format.rs
@@ -126,22 +126,22 @@ mod tests {
         assert!(snapshot(&crate::share::fixtures::sample_summary()).contains("rank: unranked"));
     }
 
-    /// An interrupt-only window's summary carries no duration stats — the
-    /// snapshot must not emit a zero-valued `completion_duration:` record,
-    /// but the interruption count must survive on its own record.
+    /// Duration stats and the interruption count are independent records:
+    /// an interrupt-only window emits the count and no duration record.
     #[test]
-    fn snapshot_suppresses_interrupt_only_completion() {
+    fn snapshot_reports_interruptions_independently() {
         let mut summary = crate::share::fixtures::sample_summary();
         let text = snapshot(&summary);
         assert!(text.contains("completion_duration:"));
         assert!(text.contains("completion_interrupted: 0"));
-        if let Some(duration) = summary.completion_duration.as_mut() {
-            duration.count = 0;
-            duration.interrupted = 3;
-        }
+        summary.completion_duration = None;
+        summary.interrupted = 3;
         let text = snapshot(&summary);
         assert!(!text.contains("completion_duration:"));
         assert!(text.contains("completion_interrupted: 3"));
+        // Neither → neither record (the silent-window shape is unchanged).
+        summary.interrupted = 0;
+        assert!(!snapshot(&summary).contains("completion_"));
     }
 
     #[test]

--- a/src/format/snapshot.rs
+++ b/src/format/snapshot.rs
@@ -39,7 +39,13 @@ pub fn snapshot_app(report: &AppSummary) -> String {
         if let Some(model) = &provider.favorite_model {
             lines.push(format!("  favorite_model: {}", short_model_name(model)));
         }
-        if let Some(duration) = &provider.completion_duration {
+        // An interrupt-only summary (count == 0) has no duration stats —
+        // suppress the zero-valued completion record.
+        if let Some(duration) = provider
+            .completion_duration
+            .as_ref()
+            .filter(|duration| duration.count > 0)
+        {
             lines.push(format!(
                 "  completion: p50:{} p90:{} p95:{} max:{}",
                 format_duration_ms(duration.p50_ms),

--- a/src/format/snapshot.rs
+++ b/src/format/snapshot.rs
@@ -32,10 +32,7 @@ pub fn snapshot_app(report: &AppSummary) -> String {
                 .completion_duration
                 .as_ref()
                 .map_or(0, |duration| duration.count),
-            provider
-                .completion_duration
-                .as_ref()
-                .map_or(0, |duration| duration.interrupted),
+            provider.interrupted,
             provider.scan_stats.files_seen,
             provider.scan_stats.lines_seen,
             provider.scan_stats.parse_errors,
@@ -43,13 +40,7 @@ pub fn snapshot_app(report: &AppSummary) -> String {
         if let Some(model) = &provider.favorite_model {
             lines.push(format!("  favorite_model: {}", short_model_name(model)));
         }
-        // An interrupt-only summary (count == 0) has no duration stats —
-        // suppress the zero-valued completion record.
-        if let Some(duration) = provider
-            .completion_duration
-            .as_ref()
-            .filter(|duration| duration.count > 0)
-        {
+        if let Some(duration) = &provider.completion_duration {
             lines.push(format!(
                 "  completion: p50:{} p90:{} p95:{} max:{}",
                 format_duration_ms(duration.p50_ms),
@@ -156,17 +147,16 @@ pub fn snapshot(summary: &Summary) -> String {
     lines.join("\n")
 }
 
-/// The completion records: duration stats only when a turn completed (an
-/// interrupt-only summary's zero-valued record would mislead, matching the
-/// provider subsection in `snapshot_app`), while the interruption count
-/// rides its own record so it survives interrupt-only windows.
+/// The completion records: duration stats when a turn completed, and the
+/// interruption count on its own line (independent metrics — a window can
+/// hold one without the other). A summary with neither emits nothing, so
+/// the stable snapshot shape for silent windows is unchanged.
 fn completion_lines(summary: &Summary) -> Vec<String> {
     let mut lines = Vec::new();
-    if let Some(duration) = summary
-        .completion_duration
-        .as_ref()
-        .filter(|duration| duration.count > 0)
-    {
+    if summary.completion_duration.is_none() && summary.interrupted == 0 {
+        return lines;
+    }
+    if let Some(duration) = &summary.completion_duration {
         lines.push(format!(
             "completion_duration: count:{} p50:{} p90:{} p95:{} max:{}",
             duration.count,
@@ -176,9 +166,7 @@ fn completion_lines(summary: &Summary) -> Vec<String> {
             format_duration_ms(duration.max_ms)
         ));
     }
-    if let Some(duration) = &summary.completion_duration {
-        lines.push(format!("completion_interrupted: {}", duration.interrupted));
-    }
+    lines.push(format!("completion_interrupted: {}", summary.interrupted));
     lines
 }
 

--- a/src/format/snapshot.rs
+++ b/src/format/snapshot.rs
@@ -120,7 +120,14 @@ pub fn snapshot(summary: &Summary) -> String {
             format_tokens(usage)
         ));
     }
-    if let Some(duration) = &summary.completion_duration {
+    // An interrupt-only summary (count == 0) has no duration stats —
+    // suppress the zero-valued record here too, matching the provider
+    // subsection in `snapshot_app`.
+    if let Some(duration) = summary
+        .completion_duration
+        .as_ref()
+        .filter(|duration| duration.count > 0)
+    {
         lines.push(format!(
             "completion_duration: count:{} p50:{} p90:{} p95:{} max:{}",
             duration.count,

--- a/src/format/snapshot.rs
+++ b/src/format/snapshot.rs
@@ -23,7 +23,7 @@ pub fn snapshot_app(report: &AppSummary) -> String {
     lines.push("providers:".to_owned());
     for provider in &report.providers {
         lines.push(format!(
-            "- {} volume:{} sessions:{} tools:{} durations:{} files:{} lines:{} parse_errors:{}",
+            "- {} volume:{} sessions:{} tools:{} durations:{} interrupted:{} files:{} lines:{} parse_errors:{}",
             provider.provider.label(),
             format_tokens(provider.total_usage.token_volume()),
             provider.sessions,
@@ -32,6 +32,10 @@ pub fn snapshot_app(report: &AppSummary) -> String {
                 .completion_duration
                 .as_ref()
                 .map_or(0, |duration| duration.count),
+            provider
+                .completion_duration
+                .as_ref()
+                .map_or(0, |duration| duration.interrupted),
             provider.scan_stats.files_seen,
             provider.scan_stats.lines_seen,
             provider.scan_stats.parse_errors,
@@ -120,23 +124,7 @@ pub fn snapshot(summary: &Summary) -> String {
             format_tokens(usage)
         ));
     }
-    // An interrupt-only summary (count == 0) has no duration stats —
-    // suppress the zero-valued record here too, matching the provider
-    // subsection in `snapshot_app`.
-    if let Some(duration) = summary
-        .completion_duration
-        .as_ref()
-        .filter(|duration| duration.count > 0)
-    {
-        lines.push(format!(
-            "completion_duration: count:{} p50:{} p90:{} p95:{} max:{}",
-            duration.count,
-            format_duration_ms(duration.p50_ms),
-            format_duration_ms(duration.p90_ms),
-            format_duration_ms(duration.p95_ms),
-            format_duration_ms(duration.max_ms)
-        ));
-    }
+    lines.extend(completion_lines(summary));
 
     lines.push("models:".to_owned());
     for model in summary.models.iter().take(5) {
@@ -166,6 +154,32 @@ pub fn snapshot(summary: &Summary) -> String {
     }
 
     lines.join("\n")
+}
+
+/// The completion records: duration stats only when a turn completed (an
+/// interrupt-only summary's zero-valued record would mislead, matching the
+/// provider subsection in `snapshot_app`), while the interruption count
+/// rides its own record so it survives interrupt-only windows.
+fn completion_lines(summary: &Summary) -> Vec<String> {
+    let mut lines = Vec::new();
+    if let Some(duration) = summary
+        .completion_duration
+        .as_ref()
+        .filter(|duration| duration.count > 0)
+    {
+        lines.push(format!(
+            "completion_duration: count:{} p50:{} p90:{} p95:{} max:{}",
+            duration.count,
+            format_duration_ms(duration.p50_ms),
+            format_duration_ms(duration.p90_ms),
+            format_duration_ms(duration.p95_ms),
+            format_duration_ms(duration.max_ms)
+        ));
+    }
+    if let Some(duration) = &summary.completion_duration {
+        lines.push(format!("completion_interrupted: {}", duration.interrupted));
+    }
+    lines
 }
 
 fn indent_lines(value: &str, indent: &str) -> Vec<String> {

--- a/src/model/events.rs
+++ b/src/model/events.rs
@@ -88,6 +88,13 @@ pub struct PermissionEvent {
     pub mode: String,
 }
 
+/// One user-initiated interruption: Claude's `[Request interrupted …]`
+/// marker rows (esc during a turn), Codex's `turn_aborted` events.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InterruptEvent {
+    pub timestamp: Option<OffsetDateTime>,
+}
+
 /// Per-assistant-message mode flags for Claude: whether extended thinking
 /// fired (a `thinking` content block exists — block presence only, text is
 /// never read) and whether fast mode served it (`usage.speed == "fast"`).
@@ -136,6 +143,7 @@ pub struct Collection {
     pub effort_events: Vec<EffortEvent>,
     pub mode_events: Vec<ModeEvent>,
     pub permission_events: Vec<PermissionEvent>,
+    pub interrupt_events: Vec<InterruptEvent>,
     pub stats: ScanStats,
 }
 
@@ -153,6 +161,7 @@ impl Collection {
             effort_events: Vec::new(),
             mode_events: Vec::new(),
             permission_events: Vec::new(),
+            interrupt_events: Vec::new(),
             stats: ScanStats::default(),
         }
     }
@@ -187,6 +196,9 @@ impl Collection {
             combined
                 .permission_events
                 .extend(collection.permission_events.iter().cloned());
+            combined
+                .interrupt_events
+                .extend(collection.interrupt_events.iter().cloned());
             combined.stats.add_assign(&collection.stats);
         }
         combined.stats.usage_events = combined.usage_events.len();

--- a/src/model/summary.rs
+++ b/src/model/summary.rs
@@ -140,6 +140,9 @@ impl SessionSpan {
 #[derive(Debug, Clone)]
 pub struct DurationSummary {
     pub count: usize,
+    /// User-initiated interruptions (esc / `turn_aborted`) in the window —
+    /// not part of `count`, which is completed turns only.
+    pub interrupted: usize,
     pub p50_ms: u64,
     pub p90_ms: u64,
     pub p95_ms: u64,

--- a/src/model/summary.rs
+++ b/src/model/summary.rs
@@ -137,12 +137,12 @@ impl SessionSpan {
     }
 }
 
+/// Completed-turn duration statistics. `Some` on a `Summary` guarantees at
+/// least one completed turn — interruptions live on `Summary::interrupted`,
+/// not here.
 #[derive(Debug, Clone)]
 pub struct DurationSummary {
     pub count: usize,
-    /// User-initiated interruptions (esc / `turn_aborted`) in the window —
-    /// not part of `count`, which is completed turns only.
-    pub interrupted: usize,
     pub p50_ms: u64,
     pub p90_ms: u64,
     pub p95_ms: u64,
@@ -214,6 +214,11 @@ pub struct Summary {
     pub favorite_model: Option<String>,
     pub longest_session: Option<SessionSpan>,
     pub completion_duration: Option<DurationSummary>,
+    /// User-initiated interruptions (Claude esc markers, Codex
+    /// `turn_aborted`) dated inside the window. Independent of
+    /// `completion_duration`: a window can hold interruptions and no
+    /// completed turn.
+    pub interrupted: usize,
     pub orchestration: Orchestration,
 }
 

--- a/src/share/card.rs
+++ b/src/share/card.rs
@@ -132,18 +132,24 @@ impl ShareCard {
             )
         });
 
-        let completion = summary.completion_duration.as_ref().map(|duration| {
-            let counts: Vec<usize> = duration.buckets.iter().map(|b| b.count).collect();
-            let unattended: usize = counts.iter().skip(3).sum();
-            (
-                counts,
-                unattended,
-                duration.count,
-                format_duration_ms(duration.p50_ms),
-                format_duration_ms(duration.p90_ms),
-                format_duration_ms(duration.max_ms),
-            )
-        });
+        // An interrupt-only summary (count == 0) carries no duration stats
+        // worth exporting — the card keeps its em-dash absent state.
+        let completion = summary
+            .completion_duration
+            .as_ref()
+            .filter(|duration| duration.count > 0)
+            .map(|duration| {
+                let counts: Vec<usize> = duration.buckets.iter().map(|b| b.count).collect();
+                let unattended: usize = counts.iter().skip(3).sum();
+                (
+                    counts,
+                    unattended,
+                    duration.count,
+                    format_duration_ms(duration.p50_ms),
+                    format_duration_ms(duration.p90_ms),
+                    format_duration_ms(duration.max_ms),
+                )
+            });
 
         let codename = crate::codename::for_summary(summary);
         Self {

--- a/src/share/card.rs
+++ b/src/share/card.rs
@@ -132,24 +132,18 @@ impl ShareCard {
             )
         });
 
-        // An interrupt-only summary (count == 0) carries no duration stats
-        // worth exporting — the card keeps its em-dash absent state.
-        let completion = summary
-            .completion_duration
-            .as_ref()
-            .filter(|duration| duration.count > 0)
-            .map(|duration| {
-                let counts: Vec<usize> = duration.buckets.iter().map(|b| b.count).collect();
-                let unattended: usize = counts.iter().skip(3).sum();
-                (
-                    counts,
-                    unattended,
-                    duration.count,
-                    format_duration_ms(duration.p50_ms),
-                    format_duration_ms(duration.p90_ms),
-                    format_duration_ms(duration.max_ms),
-                )
-            });
+        let completion = summary.completion_duration.as_ref().map(|duration| {
+            let counts: Vec<usize> = duration.buckets.iter().map(|b| b.count).collect();
+            let unattended: usize = counts.iter().skip(3).sum();
+            (
+                counts,
+                unattended,
+                duration.count,
+                format_duration_ms(duration.p50_ms),
+                format_duration_ms(duration.p90_ms),
+                format_duration_ms(duration.max_ms),
+            )
+        });
 
         let codename = crate::codename::for_summary(summary);
         Self {

--- a/src/share/fixtures.rs
+++ b/src/share/fixtures.rs
@@ -63,6 +63,7 @@ pub(crate) fn sample_summary() -> Summary {
         longest_session: None,
         completion_duration: Some(DurationSummary {
             count: 100,
+            interrupted: 0,
             p50_ms: 120_000,
             p90_ms: 600_000,
             p95_ms: 900_000,

--- a/src/share/fixtures.rs
+++ b/src/share/fixtures.rs
@@ -63,7 +63,6 @@ pub(crate) fn sample_summary() -> Summary {
         longest_session: None,
         completion_duration: Some(DurationSummary {
             count: 100,
-            interrupted: 0,
             p50_ms: 120_000,
             p90_ms: 600_000,
             p95_ms: 900_000,
@@ -95,6 +94,7 @@ pub(crate) fn sample_summary() -> Summary {
                 },
             ],
         }),
+        interrupted: 0,
         orchestration: Orchestration {
             avg_concurrency: 2.5,
             peak_concurrency: 4,

--- a/src/ui/page.rs
+++ b/src/ui/page.rs
@@ -119,7 +119,7 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
     // Decided chart priority: activity → token/day → by-hour → completion →
     // PARALLEL AGENTS → models → (cost/signal/projects/tools/agents).
     if width < TWO_COLUMN_MIN_WIDTH {
-        if summary.completion_duration.is_some() {
+        if summary.completion_duration.is_some() || summary.interrupted > 0 {
             lines.extend(sections::duration_lines(summary, width));
             lines.push(Line::default());
         }
@@ -159,7 +159,7 @@ pub(super) fn page_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
         .time_by_level
         .iter()
         .any(|secs| *secs > 0);
-    if summary.completion_duration.is_some() || has_parallel {
+    if summary.completion_duration.is_some() || summary.interrupted > 0 || has_parallel {
         let completion = sections::duration_lines(summary, left_u16);
         let parallel = sections::parallel_lines(summary, right_u16);
         lines.extend(join_columns(&completion, &parallel, left_width + 2));

--- a/src/ui/sections/completion.rs
+++ b/src/ui/sections/completion.rs
@@ -1,11 +1,23 @@
 use crate::format::{format_count, format_duration_ms};
-use crate::model::Summary;
+use crate::model::{DurationSummary, Summary};
 use crate::ui::{theme, utils};
 use ratatui::prelude::*;
 
+/// The COMPLETION section: duration stats when a turn completed, plus the
+/// window's interruption count in the title. A window with interruptions
+/// but no completed turn renders the title alone — the count stays visible
+/// without zero percentiles or empty bars.
 pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
-    let Some(duration) = &summary.completion_duration else {
+    let duration = summary.completion_duration.as_ref();
+    if duration.is_none() && summary.interrupted == 0 {
         return Vec::new();
+    }
+    let title = utils::section_title(
+        "COMPLETION",
+        &completion_annotation(duration, summary.interrupted, width),
+    );
+    let Some(duration) = duration else {
+        return vec![title];
     };
     let max = duration
         .buckets
@@ -13,12 +25,6 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
         .map(|bucket| bucket.count)
         .max()
         .unwrap_or(0);
-    let title = utils::section_title("COMPLETION", &completion_annotation(duration, width));
-    // An interrupt-only window (no completed turn) keeps the count visible
-    // but has no percentiles or buckets worth drawing.
-    if duration.count == 0 {
-        return vec![title];
-    }
     let mut lines = vec![
         title,
         Line::from(vec![
@@ -58,7 +64,11 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
 /// its long form when the rail has room, falls back to a compact "esc"
 /// label, and drops entirely on rails too narrow for either — never
 /// clipped mid-word. The prefix budget covers "▍ COMPLETION  ".
-fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -> String {
+fn completion_annotation(
+    duration: Option<&DurationSummary>,
+    interrupted: usize,
+    width: u16,
+) -> String {
     let budget = usize::from(width).saturating_sub("▍ COMPLETION  ".chars().count());
     let fitted = |candidates: [String; 2], fallback: String| {
         candidates
@@ -66,16 +76,16 @@ fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -
             .find(|text| text.chars().count() <= budget)
             .unwrap_or(fallback)
     };
-    let interrupted = format_count(duration.interrupted);
-    if duration.count == 0 {
+    let interrupted_label = format_count(interrupted);
+    let Some(duration) = duration else {
         return fitted(
             [
-                format!("{interrupted} interrupted"),
-                format!("{interrupted} esc"),
+                format!("{interrupted_label} interrupted"),
+                format!("{interrupted_label} esc"),
             ],
             String::new(),
         );
-    }
+    };
     let autonomous: usize = duration
         .buckets
         .iter()
@@ -87,13 +97,13 @@ fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -
         format_count(duration.count),
         format_count(autonomous)
     );
-    if duration.interrupted == 0 {
+    if interrupted == 0 {
         return base;
     }
     fitted(
         [
-            format!("{base} · {interrupted} interrupted"),
-            format!("{base} · {interrupted} esc"),
+            format!("{base} · {interrupted_label} interrupted"),
+            format!("{base} · {interrupted_label} esc"),
         ],
         base,
     )
@@ -105,9 +115,7 @@ mod tests {
 
     fn summary_with_interrupts(interrupted: usize) -> Summary {
         let mut summary = crate::share::fixtures::sample_summary();
-        if let Some(duration) = summary.completion_duration.as_mut() {
-            duration.interrupted = interrupted;
-        }
+        summary.interrupted = interrupted;
         summary
     }
 
@@ -143,10 +151,7 @@ mod tests {
     #[test]
     fn interrupt_only_window_renders_title_only() {
         let mut summary = summary_with_interrupts(3);
-        if let Some(duration) = summary.completion_duration.as_mut() {
-            duration.count = 0;
-            duration.buckets.iter_mut().for_each(|b| b.count = 0);
-        }
+        summary.completion_duration = None;
 
         let lines = duration_lines(&summary, 100);
 
@@ -161,5 +166,10 @@ mod tests {
         let title = rendered(&narrow[0]);
         assert!(title.chars().count() <= 20, "{title:?}");
         assert!(!title.contains("interrupted"), "{title:?}");
+
+        // Nothing at all to say → no section.
+        let mut silent = summary_with_interrupts(0);
+        silent.completion_duration = None;
+        assert!(duration_lines(&silent, 100).is_empty());
     }
 }

--- a/src/ui/sections/completion.rs
+++ b/src/ui/sections/completion.rs
@@ -59,8 +59,22 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
 /// label, and drops entirely on rails too narrow for either — never
 /// clipped mid-word. The prefix budget covers "▍ COMPLETION  ".
 fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -> String {
+    let budget = usize::from(width).saturating_sub("▍ COMPLETION  ".chars().count());
+    let fitted = |candidates: [String; 2], fallback: String| {
+        candidates
+            .into_iter()
+            .find(|text| text.chars().count() <= budget)
+            .unwrap_or(fallback)
+    };
+    let interrupted = format_count(duration.interrupted);
     if duration.count == 0 {
-        return format!("{} interrupted", format_count(duration.interrupted));
+        return fitted(
+            [
+                format!("{interrupted} interrupted"),
+                format!("{interrupted} esc"),
+            ],
+            String::new(),
+        );
     }
     let autonomous: usize = duration
         .buckets
@@ -76,19 +90,13 @@ fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -
     if duration.interrupted == 0 {
         return base;
     }
-    let budget = usize::from(width).saturating_sub("▍ COMPLETION  ".chars().count());
-    let long = format!(
-        "{base} · {} interrupted",
-        format_count(duration.interrupted)
-    );
-    if long.chars().count() <= budget {
-        return long;
-    }
-    let compact = format!("{base} · {} esc", format_count(duration.interrupted));
-    if compact.chars().count() <= budget {
-        return compact;
-    }
-    base
+    fitted(
+        [
+            format!("{base} · {interrupted} interrupted"),
+            format!("{base} · {interrupted} esc"),
+        ],
+        base,
+    )
 }
 
 #[cfg(test)]
@@ -146,5 +154,12 @@ mod tests {
         let title = rendered(&lines[0]);
         assert!(title.contains("3 interrupted"), "{title:?}");
         assert!(!title.contains("turns"), "{title:?}");
+
+        // The width ladder applies here too — no mid-word clipping on
+        // rails narrower than the long form.
+        let narrow = duration_lines(&summary, 20);
+        let title = rendered(&narrow[0]);
+        assert!(title.chars().count() <= 20, "{title:?}");
+        assert!(!title.contains("interrupted"), "{title:?}");
     }
 }

--- a/src/ui/sections/completion.rs
+++ b/src/ui/sections/completion.rs
@@ -13,8 +13,14 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
         .map(|bucket| bucket.count)
         .max()
         .unwrap_or(0);
+    let title = utils::section_title("COMPLETION", &completion_annotation(duration, width));
+    // An interrupt-only window (no completed turn) keeps the count visible
+    // but has no percentiles or buckets worth drawing.
+    if duration.count == 0 {
+        return vec![title];
+    }
     let mut lines = vec![
-        utils::section_title("COMPLETION", &completion_annotation(duration, width)),
+        title,
         Line::from(vec![
             Span::styled("p50 ", Style::default().fg(theme::MUTED)),
             Span::styled(
@@ -53,6 +59,9 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
 /// label, and drops entirely on rails too narrow for either — never
 /// clipped mid-word. The prefix budget covers "▍ COMPLETION  ".
 fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -> String {
+    if duration.count == 0 {
+        return format!("{} interrupted", format_count(duration.interrupted));
+    }
     let autonomous: usize = duration
         .buckets
         .iter()
@@ -119,5 +128,23 @@ mod tests {
         let zero = duration_lines(&summary_with_interrupts(0), 100);
         let title = rendered(&zero[0]);
         assert!(!title.contains("esc") && !title.contains("interrupted"));
+    }
+
+    /// An interrupt-only window (every turn aborted, none completed) keeps
+    /// the count visible as a bare title — no zero percentiles or empty bars.
+    #[test]
+    fn interrupt_only_window_renders_title_only() {
+        let mut summary = summary_with_interrupts(3);
+        if let Some(duration) = summary.completion_duration.as_mut() {
+            duration.count = 0;
+            duration.buckets.iter_mut().for_each(|b| b.count = 0);
+        }
+
+        let lines = duration_lines(&summary, 100);
+
+        assert_eq!(lines.len(), 1);
+        let title = rendered(&lines[0]);
+        assert!(title.contains("3 interrupted"), "{title:?}");
+        assert!(!title.contains("turns"), "{title:?}");
     }
 }

--- a/src/ui/sections/completion.rs
+++ b/src/ui/sections/completion.rs
@@ -13,22 +13,8 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
         .map(|bucket| bucket.count)
         .max()
         .unwrap_or(0);
-    // Autonomy signal: how often a turn ran 20+ minutes unattended.
-    let autonomous: usize = duration
-        .buckets
-        .iter()
-        .skip(3)
-        .map(|bucket| bucket.count)
-        .sum();
     let mut lines = vec![
-        utils::section_title(
-            "COMPLETION",
-            &format!(
-                "{} turns · {} ran ≥20m",
-                format_count(duration.count),
-                format_count(autonomous)
-            ),
-        ),
+        utils::section_title("COMPLETION", &completion_annotation(duration, width)),
         Line::from(vec![
             Span::styled("p50 ", Style::default().fg(theme::MUTED)),
             Span::styled(
@@ -60,4 +46,78 @@ pub(in crate::ui) fn duration_lines(summary: &Summary, width: u16) -> Vec<Line<'
         ));
     }
     lines
+}
+
+/// The section annotation, width-fitted: the interruption count appends in
+/// its long form when the rail has room, falls back to a compact "esc"
+/// label, and drops entirely on rails too narrow for either — never
+/// clipped mid-word. The prefix budget covers "▍ COMPLETION  ".
+fn completion_annotation(duration: &crate::model::DurationSummary, width: u16) -> String {
+    let autonomous: usize = duration
+        .buckets
+        .iter()
+        .skip(3)
+        .map(|bucket| bucket.count)
+        .sum();
+    let base = format!(
+        "{} turns · {} ran ≥20m",
+        format_count(duration.count),
+        format_count(autonomous)
+    );
+    if duration.interrupted == 0 {
+        return base;
+    }
+    let budget = usize::from(width).saturating_sub("▍ COMPLETION  ".chars().count());
+    let long = format!(
+        "{base} · {} interrupted",
+        format_count(duration.interrupted)
+    );
+    if long.chars().count() <= budget {
+        return long;
+    }
+    let compact = format!("{base} · {} esc", format_count(duration.interrupted));
+    if compact.chars().count() <= budget {
+        return compact;
+    }
+    base
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary_with_interrupts(interrupted: usize) -> Summary {
+        let mut summary = crate::share::fixtures::sample_summary();
+        if let Some(duration) = summary.completion_duration.as_mut() {
+            duration.interrupted = interrupted;
+        }
+        summary
+    }
+
+    fn rendered(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    /// The 80-column layout's rail must not clip the title mid-word: the
+    /// interruption count falls back to "esc" and then drops entirely.
+    #[test]
+    fn completion_title_fits_narrow_rails() {
+        let summary = summary_with_interrupts(12);
+
+        let wide = duration_lines(&summary, 100);
+        let title = rendered(&wide[0]);
+        assert!(title.contains("12 interrupted"), "{title:?}");
+
+        let narrow = duration_lines(&summary, 44);
+        let title = rendered(&narrow[0]);
+        assert!(title.chars().count() <= 44, "{title:?}");
+        assert!(!title.contains("interrupted"), "{title:?}");
+
+        let zero = duration_lines(&summary_with_interrupts(0), 100);
+        let title = rendered(&zero[0]);
+        assert!(!title.contains("esc") && !title.contains("interrupted"));
+    }
 }


### PR DESCRIPTION
## Summary

Turns aborted with esc were invisible: you couldn't see how often runs get cut short, and on the Claude side the aborted turn's partial duration leaked into completion percentiles.

- The COMPLETION title now shows the window's interruption count, width-fitted (`· N interrupted` → `· N esc` → dropped on rails too narrow for either — never clipped mid-word)
- Claude counts `[Request interrupted by user…]` marker rows, gated against quoted-marker and meta rows; sidechain echoes are excluded because one esc fans out into every subagent transcript (10–16 rows observed, ~1.8× overcount). The trade-off — escs recorded only in sidechain files (~14%) go uncounted — matches the Codex ruling below
- Codex counts `turn_aborted` events, deduped by turn id across fork replays; `sub_agent_activity: interrupted` is deliberately discarded
- Claude aborted turns are now discarded from completion durations instead of being measured to the marker row, matching Codex where `turn_aborted` never reaches the durations

Cache version bumps to 16 (parse-semantics change).

## Test Plan

- `cargo test` (154, including: marker gating false-positive cases, fork-replay single-count, aborted-turn duration exclusion, title width fallback at 44/100 columns)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- Probed against real logs: 30-day window yields 1,920 completed turns / 61 interruptions, annotation renders as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)