### PR TITLE
COST: show — instead of $0 when pricing is unknown

### DIFF
--- a/src/cost.rs
+++ b/src/cost.rs
@@ -176,6 +176,53 @@ pub fn usage_cost_usd(model_name: &str, usage: &TokenUsage) -> Option<f64> {
     )
 }
 
+/// A cost sum that keeps "no price known" distinct from "$0". Token volume
+/// whose model has no pricing (the LiteLLM table unreachable and uncached,
+/// or an id the table lacks) is tallied as `unpriced_volume` — never folded
+/// into `priced_usd` as zero, which is what made an offline run render
+/// "$0.00 API-equivalent" on the share card.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct CostTally {
+    /// USD over the entries that could be priced (provider-reported cost is
+    /// always priced — it is an actual charge).
+    pub priced_usd: f64,
+    /// Token volume that had no price and is therefore missing from
+    /// `priced_usd`.
+    pub unpriced_volume: u64,
+}
+
+impl CostTally {
+    /// Add one model's block: its provider-reported cost (if any) plus the
+    /// priced or unpriced share of the tokens that had no reported cost.
+    pub fn add(
+        &mut self,
+        model_name: &str,
+        unreported: &TokenUsage,
+        reported_cost_usd: Option<f64>,
+    ) {
+        self.priced_usd += reported_cost_usd.unwrap_or(0.0);
+        let volume = unreported.token_volume();
+        if volume == 0 {
+            return;
+        }
+        match usage_cost_usd(model_name, unreported) {
+            Some(cost) => self.priced_usd += cost,
+            None => self.unpriced_volume = self.unpriced_volume.saturating_add(volume),
+        }
+    }
+
+    /// True when every token that needed a price got one.
+    pub fn is_complete(&self) -> bool {
+        self.unpriced_volume == 0
+    }
+
+    /// The total, only when it is the whole picture — a partial sum is not
+    /// a total.
+    pub fn complete_usd(&self) -> Option<f64> {
+        self.is_complete().then_some(self.priced_usd)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -382,5 +429,35 @@ mod tests {
         assert!((cost - 10.5).abs() < 1e-9);
         // Versionless fallback id stays unpriced — too ambiguous to map.
         assert!(usage_cost_usd("gemini-pro-default", &usage).is_none());
+    }
+
+    /// An unpriced model's volume never lands in the sum as $0: the tally
+    /// records the gap and refuses to call the partial sum a total.
+    #[test]
+    fn tally_keeps_unpriced_volume_out_of_the_sum() {
+        install_test_pricing();
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            ..TokenUsage::default()
+        };
+
+        let mut priced = CostTally::default();
+        priced.add("claude-opus-4-8", &usage, None);
+        assert!(priced.is_complete());
+        assert!((priced.complete_usd().unwrap_or(0.0) - 5.0).abs() < 1e-9);
+
+        let mut mixed = CostTally::default();
+        mixed.add("claude-opus-4-8", &usage, None);
+        mixed.add("model-nobody-priced", &usage, Some(0.25));
+        // The reported charge is real and counts; the unpriced tokens do not
+        // become $0 — they make the total unknowable.
+        assert!((mixed.priced_usd - 5.25).abs() < 1e-9);
+        assert_eq!(mixed.unpriced_volume, 1_000_000);
+        assert_eq!(mixed.complete_usd(), None);
+
+        // Zero tokens need no price and leave the tally complete.
+        let mut empty = CostTally::default();
+        empty.add("model-nobody-priced", &TokenUsage::default(), None);
+        assert!(empty.is_complete());
     }
 }

--- a/src/share/card.rs
+++ b/src/share/card.rs
@@ -3,7 +3,7 @@ use std::fmt::Write as _;
 
 use time::{Date, Duration};
 
-use crate::cost::usage_cost_usd;
+use crate::cost::CostTally;
 use crate::format::{
     format_duration_ms, format_percent, format_tokens, format_usd, short_model_name,
 };
@@ -25,10 +25,15 @@ pub struct ShareCard {
     pub(crate) period_days: u16,
     pub(crate) active_days: usize,
     pub(crate) tokens: String,
-    pub(crate) cost: String,
-    /// True when `cost` includes a provider-reported figure (Cursor), which is an
-    /// actual charge fetched over the network — not an API-equivalent estimate
-    /// from local logs. Softens the caption's "API-equivalent / 100% local" copy.
+    /// Formatted API-equivalent cost, or `None` when some of the window's
+    /// tokens had no known price (LiteLLM table unreachable / model id
+    /// missing) — the card then shows "—" rather than an undercounted figure.
+    pub(crate) cost: Option<String>,
+    /// True when the window contains a provider-reported cost (Cursor) — an
+    /// actual charge fetched over the network, not an API-equivalent estimate
+    /// from local logs. Independent of whether `cost` could be shown (other
+    /// usage may be unpriced); softens the caption's "API-equivalent / 100%
+    /// local" copy either way.
     pub(crate) has_reported_cost: bool,
     pub(crate) sessions: usize,
     /// Top models: (short name, share%, ratio-to-largest, `formatted_tokens`).
@@ -63,14 +68,14 @@ impl ShareCard {
     )]
     pub fn from_summary(summary: &Summary) -> Self {
         let total = summary.total_usage.token_volume();
-        let cost: f64 = summary
-            .model_daily
-            .iter()
-            .map(|entry| {
-                entry.reported_cost_usd.unwrap_or(0.0)
-                    + usage_cost_usd(&entry.model, &entry.unreported_usage).unwrap_or(0.0)
-            })
-            .sum();
+        let mut tally = CostTally::default();
+        for entry in &summary.model_daily {
+            tally.add(
+                &entry.model,
+                &entry.unreported_usage,
+                entry.reported_cost_usd,
+            );
+        }
         let has_reported_cost = summary
             .model_daily
             .iter()
@@ -154,7 +159,7 @@ impl ShareCard {
             period_days: summary.period_days,
             active_days: summary.active_days,
             tokens: format_tokens(total),
-            cost: format_usd(cost),
+            cost: tally.complete_usd().map(format_usd),
             has_reported_cost,
             sessions: summary.sessions,
             models,
@@ -168,14 +173,17 @@ impl ShareCard {
 
     /// A ready-to-post caption (X body / clipboard text).
     pub fn caption(&self) -> String {
+        let mut stats = vec![format!("{} tokens", self.tokens)];
         // Cursor's reported cost is an actual charge, not an API-equivalent
-        // estimate, so don't label it as one.
-        let cost_label = if self.has_reported_cost {
-            format!("{} cost", self.cost)
-        } else {
-            format!("{} API-equivalent", self.cost)
-        };
-        let mut stats = vec![format!("{} tokens", self.tokens), cost_label];
+        // estimate, so don't label it as one. An unknown cost is simply
+        // absent — a "$0" would misread as free.
+        if let Some(cost) = &self.cost {
+            stats.push(if self.has_reported_cost {
+                format!("{cost} cost")
+            } else {
+                format!("{cost} API-equivalent")
+            });
+        }
         if let Some((four_plus_pct, peak)) = &self.parallel
             && *four_plus_pct > 0
         {

--- a/src/share/svg.rs
+++ b/src/share/svg.rs
@@ -132,15 +132,17 @@ fn draw_header(s: &mut String, card: &ShareCard) {
         card.active_days, card.period_days, card.sessions
     );
     // Cursor's reported cost is an actual charge, not an API-equivalent estimate.
+    // An unknown cost renders as "—" — never "$0", which would misread as free.
     let cost_label = if card.has_reported_cost {
         "cost"
     } else {
         "api-equiv"
     };
+    let cost = card.cost.as_deref().unwrap_or("—");
     let _ = write!(
         s,
-        r#"<text x="{RX}" y="100" fill="{C_MUTED}" font-size="18" text-anchor="end">{} tokens   ·   {} {}</text>"#,
-        card.tokens, card.cost, cost_label
+        r#"<text x="{RX}" y="100" fill="{C_MUTED}" font-size="18" text-anchor="end">{} tokens   ·   {cost} {cost_label}</text>"#,
+        card.tokens
     );
 
     let _ = write!(

--- a/src/share/tests.rs
+++ b/src/share/tests.rs
@@ -75,6 +75,32 @@ fn every_badge_rasterizes() {
     }
 }
 
+/// A card whose window holds tokens with no known price shows "—" instead of
+/// an undercounted "$0" — and its caption drops the cost stat entirely.
+#[test]
+fn unpriced_cost_renders_as_dash_not_zero() {
+    let mut summary = sample_summary();
+    let usage = crate::model::TokenUsage {
+        input_tokens: 1_000_000,
+        ..crate::model::TokenUsage::default()
+    };
+    summary.model_daily.push(crate::model::ModelDailyStat {
+        date: summary.period_end,
+        model: "model-nobody-priced".to_owned(),
+        usage: usage.clone(),
+        unreported_usage: usage,
+        reported_cost_usd: None,
+    });
+    let card = ShareCard::from_summary(&summary);
+    assert_eq!(card.cost, None);
+    let rendered = svg(&card);
+    assert!(rendered.contains("—"), "{rendered}");
+    assert!(!rendered.contains("$0"), "{rendered}");
+    let caption = card.caption();
+    assert!(!caption.contains("API-equivalent"), "{caption}");
+    assert!(!caption.contains("$0"), "{caption}");
+}
+
 #[test]
 fn caption_includes_headline_and_repo() {
     let card = ShareCard::from_summary(&sample_summary());

--- a/src/ui/sections/cost.rs
+++ b/src/ui/sections/cost.rs
@@ -1,5 +1,5 @@
-use crate::cost::usage_cost_usd;
-use crate::format::{format_usd, short_model_name};
+use crate::cost::CostTally;
+use crate::format::{format_tokens, format_usd, short_model_name};
 use crate::model::Summary;
 use crate::ui::{theme, utils};
 use ratatui::prelude::*;
@@ -7,65 +7,63 @@ use time::Duration;
 
 /// API-equivalent spend, cache-aware, that answers "is the subscription paying
 /// for itself". Shows trailing windows (today / 7d / 30d) cut from the per-day,
-/// per-model aggregates.
+/// per-model aggregates. Tokens with no known price (LiteLLM unreachable and
+/// uncached, or a model id the table lacks) are never summed as $0: a fully
+/// unpriced window renders "—", a partially priced one flags the gap.
 pub(in crate::ui) fn cost_lines(summary: &Summary, width: u16) -> Vec<Line<'static>> {
     let label_width = utils::kv_label_width(width);
-    // Cursor contributes its own reported cost (an actual charge, not a LiteLLM
-    // estimate), so qualify the annotation when any of it is in the total.
-    let has_reported = summary
-        .models
-        .iter()
-        .any(|model| model.reported_cost_usd.is_some());
-    let annotation = if width < 44 {
-        if has_reported {
-            "incl. reported".to_owned()
-        } else {
-            "api-equivalent".to_owned()
-        }
-    } else {
-        let base = crate::cost::pricing_as_of().map_or_else(
-            || "api-equivalent · cache-aware".to_owned(),
-            |date| format!("api-equivalent · rates {date}"),
-        );
-        if has_reported {
-            format!("{base} · incl. provider-reported")
-        } else {
-            base
-        }
-    };
-    let mut total = 0.0_f64;
+    let mut total = CostTally::default();
     let mut per_model: Vec<(String, f64)> = Vec::new();
     for model in &summary.models {
         // Provider-reported cost (Cursor) plus the LiteLLM price of the tokens
         // that had no reported cost — additive so a model name shared by a
         // reporting and a non-reporting provider prices both halves.
-        let cost = model.reported_cost_usd.unwrap_or(0.0)
-            + usage_cost_usd(&model.name, &model.unreported_usage).unwrap_or(0.0);
-        if cost > 0.0 {
-            total += cost;
-            per_model.push((short_model_name(&model.name), cost));
+        let mut tally = CostTally::default();
+        tally.add(
+            &model.name,
+            &model.unreported_usage,
+            model.reported_cost_usd,
+        );
+        total.priced_usd += tally.priced_usd;
+        total.unpriced_volume = total.unpriced_volume.saturating_add(tally.unpriced_volume);
+        if tally.priced_usd > 0.0 {
+            per_model.push((short_model_name(&model.name), tally.priced_usd));
         }
     }
-    if total < 0.01 {
+    if total.priced_usd < 0.01 && total.is_complete() {
         return Vec::new();
     }
     per_model.sort_by(|left, right| right.1.total_cmp(&left.1));
 
-    let mut lines = vec![utils::section_title("COST", &annotation)];
+    let mut lines = vec![utils::section_title(
+        "COST",
+        &annotation(summary, &total, width),
+    )];
+    if total.priced_usd < 0.01 {
+        // Nothing could be priced: one honest "—" row instead of a vanished
+        // section (which reads as "no cost").
+        lines.push(cost_row(
+            &format!("{} days", summary.period_days),
+            None,
+            true,
+            label_width,
+        ));
+        return lines;
+    }
     for (label, window_days) in [("Today", 1_u16), ("7 days", 7), ("30 days", 30)] {
         if window_days >= summary.period_days {
             break;
         }
         lines.push(cost_row(
             label,
-            window_cost_usd(summary, window_days),
+            window_cost(summary, window_days).complete_usd(),
             false,
             label_width,
         ));
     }
     lines.push(cost_row(
         &format!("{} days", summary.period_days),
-        total,
+        total.complete_usd(),
         true,
         label_width,
     ));
@@ -84,7 +82,50 @@ pub(in crate::ui) fn cost_lines(summary: &Summary, width: u16) -> Vec<Line<'stat
     lines
 }
 
-fn cost_row(label: &str, cost: f64, emphasize: bool, label_width: usize) -> Line<'static> {
+/// The title annotation: rate provenance, plus the unpriced gap when any
+/// token in the window had no price.
+fn annotation(summary: &Summary, total: &CostTally, width: u16) -> String {
+    // Cursor contributes its own reported cost (an actual charge, not a LiteLLM
+    // estimate), so qualify the annotation when any of it is in the total.
+    let has_reported = summary
+        .models
+        .iter()
+        .any(|model| model.reported_cost_usd.is_some());
+    if !total.is_complete() {
+        // Width-fitted like the COMPLETION title: longest form that fits the
+        // rail after "▍ COST  ", falling back to the bare gap.
+        let budget = usize::from(width).saturating_sub("▍ COST  ".chars().count());
+        let unpriced = format_tokens(total.unpriced_volume);
+        return [
+            format!("{unpriced} tokens unpriced · rates unavailable"),
+            format!("{unpriced} tokens unpriced"),
+        ]
+        .into_iter()
+        .find(|text| text.chars().count() <= budget)
+        .unwrap_or_else(|| format!("{unpriced} unpriced"));
+    }
+    if width < 44 {
+        if has_reported {
+            "incl. reported".to_owned()
+        } else {
+            "api-equivalent".to_owned()
+        }
+    } else {
+        let base = crate::cost::pricing_as_of().map_or_else(
+            || "api-equivalent · cache-aware".to_owned(),
+            |date| format!("api-equivalent · rates {date}"),
+        );
+        if has_reported {
+            format!("{base} · incl. provider-reported")
+        } else {
+            base
+        }
+    }
+}
+
+/// A label/value row; `None` renders "—" for a value that could not be
+/// fully priced.
+fn cost_row(label: &str, cost: Option<f64>, emphasize: bool, label_width: usize) -> Line<'static> {
     let value_style = if emphasize {
         Style::default()
             .fg(theme::GOLD)
@@ -97,21 +138,76 @@ fn cost_row(label: &str, cost: f64, emphasize: bool, label_width: usize) -> Line
             format!("{label:<label_width$}"),
             Style::default().fg(theme::MUTED),
         ),
-        Span::styled(format_usd(cost), value_style),
+        Span::styled(cost.map_or_else(|| "—".to_owned(), format_usd), value_style),
     ])
 }
 
 /// Cost over the trailing `days` ending at the period end, summed from the
-/// per-day per-model usage (cache-aware per entry).
-fn window_cost_usd(summary: &Summary, days: u16) -> f64 {
+/// per-day per-model usage (cache-aware per entry), unpriced volume kept
+/// separate.
+fn window_cost(summary: &Summary, days: u16) -> CostTally {
     let start = summary.period_end - Duration::days(i64::from(days) - 1);
-    summary
+    let mut tally = CostTally::default();
+    for entry in summary
         .model_daily
         .iter()
         .filter(|entry| entry.date >= start)
-        .map(|entry| {
-            entry.reported_cost_usd.unwrap_or(0.0)
-                + usage_cost_usd(&entry.model, &entry.unreported_usage).unwrap_or(0.0)
-        })
-        .sum()
+    {
+        tally.add(
+            &entry.model,
+            &entry.unreported_usage,
+            entry.reported_cost_usd,
+        );
+    }
+    tally
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{ModelDailyStat, TokenUsage};
+
+    fn rendered(line: &Line<'_>) -> String {
+        line.spans
+            .iter()
+            .map(|span| span.content.as_ref())
+            .collect()
+    }
+
+    /// An unpriced model never sums as $0: the total row shows "—" and the
+    /// title annotation names the gap, fitted to the rail at every width.
+    #[test]
+    fn unpriced_usage_shows_dash_and_fits_narrow_rails() {
+        let mut summary = crate::share::fixtures::sample_summary();
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            ..TokenUsage::default()
+        };
+        summary.models[0].name = "model-nobody-priced".to_owned();
+        summary.models[0].unreported_usage = usage.clone();
+        summary.model_daily.push(ModelDailyStat {
+            date: summary.period_end,
+            model: "model-nobody-priced".to_owned(),
+            usage: usage.clone(),
+            unreported_usage: usage,
+            reported_cost_usd: None,
+        });
+
+        let wide = cost_lines(&summary, 100);
+        assert!(!wide.is_empty(), "an unpriced window still renders COST");
+        let title = rendered(&wide[0]);
+        assert!(title.contains("unpriced"), "{title:?}");
+        assert!(!wide.iter().any(|line| rendered(line).contains("$0")));
+        assert!(wide.iter().any(|line| rendered(line).contains('—')));
+
+        for width in [44_u16, 60, 80] {
+            let lines = cost_lines(&summary, width);
+            let title = rendered(&lines[0]);
+            assert!(
+                title.chars().count() <= usize::from(width),
+                "width {width}: {title:?}"
+            );
+            assert!(title.contains("unpriced"), "{title:?}");
+        }
+    }
 }

--- a/src/ui/sections/cost.rs
+++ b/src/ui/sections/cost.rs
@@ -93,16 +93,26 @@ fn annotation(summary: &Summary, total: &CostTally, width: u16) -> String {
         .any(|model| model.reported_cost_usd.is_some());
     if !total.is_complete() {
         // Width-fitted like the COMPLETION title: longest form that fits the
-        // rail after "▍ COST  ", falling back to the bare gap.
+        // rail after "▍ COST  ", falling back to the bare gap. The reported-
+        // cost provenance survives alongside the gap — the per-model rows
+        // still show those actual charges.
         let budget = usize::from(width).saturating_sub("▍ COST  ".chars().count());
         let unpriced = format_tokens(total.unpriced_volume);
-        return [
-            format!("{unpriced} tokens unpriced · rates unavailable"),
-            format!("{unpriced} tokens unpriced"),
-        ]
-        .into_iter()
-        .find(|text| text.chars().count() <= budget)
-        .unwrap_or_else(|| format!("{unpriced} unpriced"));
+        let candidates = if has_reported {
+            [
+                format!("{unpriced} tokens unpriced · incl. provider-reported"),
+                format!("{unpriced} unpriced · incl. reported"),
+            ]
+        } else {
+            [
+                format!("{unpriced} tokens unpriced · rates unavailable"),
+                format!("{unpriced} tokens unpriced"),
+            ]
+        };
+        return candidates
+            .into_iter()
+            .find(|text| text.chars().count() <= budget)
+            .unwrap_or_else(|| format!("{unpriced} unpriced"));
     }
     if width < 44 {
         if has_reported {
@@ -208,6 +218,28 @@ mod tests {
                 "width {width}: {title:?}"
             );
             assert!(title.contains("unpriced"), "{title:?}");
+        }
+    }
+
+    /// Provider-reported charges keep their provenance in the title even when
+    /// other usage is unpriced — the per-model rows still show real dollars.
+    #[test]
+    fn unpriced_annotation_keeps_reported_provenance() {
+        let mut summary = crate::share::fixtures::sample_summary();
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            ..TokenUsage::default()
+        };
+        summary.models[0].name = "model-nobody-priced".to_owned();
+        summary.models[0].unreported_usage = usage.clone();
+        summary.models[0].reported_cost_usd = Some(3.5);
+
+        for width in [44_u16, 100] {
+            let lines = cost_lines(&summary, width);
+            let title = rendered(&lines[0]);
+            assert!(title.chars().count() <= usize::from(width), "{title:?}");
+            assert!(title.contains("unpriced"), "{title:?}");
+            assert!(title.contains("reported"), "{title:?}");
         }
     }
 }


### PR DESCRIPTION
## Summary

When the LiteLLM pricing table can't be fetched (it lives on raw.githubusercontent.com — the 2026-08-17 GitHub outage) or a model id is missing from it, cost lookups return nothing and every consumer folded that into `$0`. The share card posted "$0.00 API-equivalent", which reads as free.

- Share card: an unknown cost renders as `—` in the SVG and the caption drops the cost stat entirely — never `$0`
- COST section: a fully unpriced window shows a `—` row instead of vanishing; a partially priced one shows `—` for the incomplete windows and the title names the gap (`N tokens unpriced`), width-fitted like the COMPLETION title
- Provider-reported cost (Cursor) is an actual charge and still counts; only estimate-less tokens are held out of the sum

## Test Plan

- `cargo test` (161: tally arithmetic incl. mixed reported/unpriced, card `—`/caption, COST `—` row + annotation at 44/60/80/100 columns)
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- Grepped every `usage_cost_usd` / `reported_cost_usd` consumer — no remaining None→0 fold on the display path

🤖 Generated with [Claude Code](https://claude.com/claude-code)