### PR TITLE
Release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,30 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **MODES**: the autonomy mix — how much of the month ran under each
-  permission mode. Claude's `permissionMode` (default / acceptEdits / plan /
-  bypass / auto) and Codex's `approval_policy` (never / on-request …), read
-  alongside the effort mix: how much rope you actually give the agent.
-- **COMPLETION**: interruption count in the title — turns you cut short.
-  Claude esc markers and Codex `turn_aborted`, deduped across resume / fork
-  copies. Interrupted turns no longer leak into the completion percentiles,
-  so p50 / p90 describe turns that actually finished. Also in `--snapshot`
-  as `completion_interrupted`.
+- MODES: how much rope you give the agent — an autonomy mix by permission
+  mode. Claude `permissionMode` and Codex `approval_policy`, next to the
+  effort mix.
+- COMPLETION: how many turns you cut short. Esc on Claude, `turn_aborted`
+  on Codex; interrupted turns no longer skew the completion percentiles.
 
 ### Fixed
 
-- Cost no longer reads `$0` when pricing is unknown. If the LiteLLM pricing
-  table can't be fetched (it lives on raw.githubusercontent.com) or a model
-  id is missing from it, the share card shows `—` and drops the cost line
-  from its caption, and the COST section shows `—` rows and names the
-  unpriced volume — instead of silently summing those tokens as free.
-- Release tweets no longer cut a sentence mid-word. Bullets that don't fit
-  are dropped whole.
+- Cost shows `—` instead of `$0` when pricing is unknown. Applies to a
+  missing model id or an unreachable LiteLLM table, on the share card and
+  in COST.
+- Release tweets no longer cut sentences mid-word.
 
 ### Changed
 
-- `resvg` 0.48: text rendering now on the fontations / harfrust stack.
-  Share-card text may differ by a sub-pixel or two.
+- resvg 0.48 moves text rendering to the fontations / harfrust stack.
+  Share-card text may shift by a sub-pixel.
 
 ## [0.13.2] - 2026-08-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-08-19
+
+### Added
+
+- **MODES**: the autonomy mix — how much of the month ran under each
+  permission mode. Claude's `permissionMode` (default / acceptEdits / plan /
+  bypass / auto) and Codex's `approval_policy` (never / on-request …), read
+  alongside the effort mix: how much rope you actually give the agent.
+- **COMPLETION**: interruption count in the title — turns you cut short.
+  Claude esc markers and Codex `turn_aborted`, deduped across resume / fork
+  copies. Interrupted turns no longer leak into the completion percentiles,
+  so p50 / p90 describe turns that actually finished. Also in `--snapshot`
+  as `completion_interrupted`.
+
+### Fixed
+
+- Cost no longer reads `$0` when pricing is unknown. If the LiteLLM pricing
+  table can't be fetched (it lives on raw.githubusercontent.com) or a model
+  id is missing from it, the share card shows `—` and drops the cost line
+  from its caption, and the COST section shows `—` rows and names the
+  unpriced volume — instead of silently summing those tokens as free.
+- Release tweets no longer cut a sentence mid-word. Bullets that don't fit
+  are dropped whole.
+
+### Changed
+
+- `resvg` 0.48: text rendering now on the fontations / harfrust stack.
+  Share-card text may differ by a sub-pixel or two.
+
 ## [0.13.2] - 2026-08-14
 
 ### Added
@@ -363,6 +392,7 @@ First public release with the codename system and the shareable stats card.
 Initial npm packaging.
 
 [#36]: https://github.com/miiiiiiich/agent-walker/issues/36
+[0.14.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/miiiiiiich/agent-walker/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/miiiiiiich/agent-walker/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.12.0...v0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-walker"
-version = "0.13.2"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-walker"
-version = "0.13.2"
+version = "0.14.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Local AI coding-agent usage dashboard — tokens, cost, projects, autonomy."


### PR DESCRIPTION
## Summary

Version bump to 0.14.0 and the changelog section that becomes the release body and tweet — please review the wording, it ships verbatim.

## Changes since v0.13.2

**Feature**
- #62 MODES: granted-autonomy mix (Claude permissionMode, Codex approval_policy)
- #63 COMPLETION: count user-interrupted turns

**Fix**
- #64 COST: show — instead of $0 when pricing is unknown
- #61 Tweet whole sentences; version-only release titles

**Deps**
- #60 Bump resvg from 0.47.0 to 0.48.1
- #59 Bump actions/setup-python from 5.6.0 to 7.0.0

**Docs**
- e15c8ff Docs: effort mix is no longer Codex-only

## Required actions at release

No special actions. Merge → tag `v0.14.0` on main → release.yml builds, publishes, and tweets.

Tweet preview (generated from this changelog, 244/280 weight):
```
agent-walker v0.14.0

・Added: MODES: how much rope you give the agent — an autonomy mix by permission mode
・Added: COMPLETION: how many turns you cut short
・Fixed: Cost shows — instead of $0 when pricing is unknown

https://github.com/miiiiiiich/agent-walker/releases/tag/v0.14.0
```

## Test Plan

- `cargo test` 162 · `scripts` pytest 17
- `draft_release.changelog_section("0.14.0")` resolves; `check_version_matches` passes
- cargo-dist 0.32.0 is upstream latest — no regen needed