### PR TITLE
Release 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.0] - 2026-08-30
+
+### Added
+
+- CONTEXT: where your input-equivalent cost actually goes. Cached share in
+  the title, then cache re-reads by context size, resumes after the cache
+  expired, session cold starts, and ordinary new input — each per call, so
+  "keep going at 500K" and "start a fresh session" compare on one scale.
+  Fixed 30-day window, every tab including Total.
+- The share card shows the cached share next to the API-equivalent cost
+  on 30-day reports. The caption now fits X's 280-character limit.
+
+### Changed
+
+- Right column now reads CONTEXT, MODES, then COST, SIGNAL. How you drive
+  the agent sits above the bookkeeping.
+- `--snapshot` gains `context_30d` records for the combined report and
+  each provider.
+
 ## [0.14.0] - 2026-08-19
 
 ### Added
@@ -385,6 +404,7 @@ First public release with the codename system and the shareable stats card.
 Initial npm packaging.
 
 [#36]: https://github.com/miiiiiiich/agent-walker/issues/36
+[0.15.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.14.0...v0.15.0
 [0.14.0]: https://github.com/miiiiiiich/agent-walker/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/miiiiiiich/agent-walker/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/miiiiiiich/agent-walker/compare/v0.13.0...v0.13.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "agent-walker"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "agent-walker"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 rust-version = "1.95"
 description = "Local AI coding-agent usage dashboard — tokens, cost, projects, autonomy."


### PR DESCRIPTION
## Summary

Version bump to 0.15.0 and the changelog section that becomes the release body and tweet — please review the wording, it ships verbatim.

## Changes since v0.14.0

**Feature**
- #70 CONTEXT: cache reuse — where the input-equivalent cost goes (TUI section on every tab, share card cached share, `--snapshot` records)

**Deps**
- #69 Bump taiki-e/install-action from 2.85.12 to 2.87.0
- #68 Bump astral-sh/setup-uv from 10.0.0 to 10.0.1

## Required actions at release

No special actions. Merge → tag `v0.15.0` on main → release.yml builds, publishes, and tweets.

Tweet preview (generated from this changelog):
```
agent-walker v0.15.0

・Added: CONTEXT: where your input-equivalent cost actually goes
・Added: The share card shows the cached share next to the API-equivalent cost on 30-day reports
・Changed: Right column now reads CONTEXT, MODES, then COST, SIGNAL

https://github.com/miiiiiiich/agent-walker/releases/tag/v0.15.0
```

## Test Plan

- `cargo test` 182 · `scripts` pytest 17
- `draft_release.changelog_section("0.15.0")` resolves; `check_version_matches` passes
- cargo-dist 0.32.0 is upstream latest — no regen needed